### PR TITLE
Enable Immersive Mode

### DIFF
--- a/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -222,6 +222,24 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     // This is what SDL runs in. It invokes SDL_main(), eventually
     protected static Thread mSDLThread;
 
+    private void setImmersiveMode() {
+    if (Build.VERSION.SDK_INT >= 19) {
+        View decorView = getWindow().getDecorView();
+        int flags =
+            View.SYSTEM_UI_FLAG_FULLSCREEN |
+            View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
+            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY |
+            View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+            View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
+            View.SYSTEM_UI_FLAG_LAYOUT_STABLE;
+
+        decorView.setSystemUiVisibility(flags);
+        }
+    SDLActivity.onNativeResize();
+    }
+
+
+
     protected static SDLGenericMotionListener_API12 getMotionListener() {
         if (mMotionListener == null) {
             if (Build.VERSION.SDK_INT >= 26 /* Android 8.0 (O) */) {
@@ -413,6 +431,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         }
 
         setContentView(mLayout);
+        setImmersiveMode();
 
         setWindowStyle(false);
 
@@ -530,6 +549,9 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
         Log.v(TAG, "onWindowFocusChanged(): " + hasFocus);
+        if (hasFocus) {
+            setImmersiveMode();
+        }
 
         if (SDLActivity.mBrokenLibraries) {
            return;


### PR DESCRIPTION
Enable Immersive Mode to hide android notification bar and home button panel as temporary fix for content being hidden behind said panels. Similar to how video players and games hide notification bar and home button panel.

Does not resize SDL canvas in any way.