### PR TITLE
Fix Access Violation in Injector::BackgroundReload due to race condition

### DIFF
--- a/CasioEmuMsvc/Gui/Injector.cpp
+++ b/CasioEmuMsvc/Gui/Injector.cpp
@@ -32,7 +32,9 @@ Injector::Injector() : UIWindow("Rop"), needsReload(false), isReloading(false), 
 Injector::~Injector() {
 	isShuttingDown.store(true);
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	if (reloadThread.joinable()) {
+		reloadThread.join();
+	}
 }
 
 std::string Injector::GetFileModifiedTime(const std::string& filepath) {
@@ -51,7 +53,12 @@ void Injector::AsyncLoadCustomInjections() {
 		if (isShuttingDown.load()) {
 			return;
 		}
-		std::thread t([this]() {
+
+		if (reloadThread.joinable()) {
+			reloadThread.join();
+		}
+
+		reloadThread = std::thread([this]() {
 			try {
 				if (!isShuttingDown.load()) {
 					BackgroundReload();
@@ -61,10 +68,6 @@ void Injector::AsyncLoadCustomInjections() {
 				// Catch exceptions
 			}
 		});
-
-		if (t.joinable()) {
-			t.detach();
-		}
 	}
 	catch (...) {
 		// Thread creation error handling
@@ -473,25 +476,7 @@ void Injector::RenderCustomInjectTab(bool& show_info, std::string& info_msg) {
 			}
 			needsReload = true;
 
-			try {
-				std::thread t([this]() {
-					try {
-						if (!isShuttingDown.load()) {
-							BackgroundReload();
-						}
-					}
-					catch (...) {
-						// Catch exceptions
-					}
-				});
-
-				if (t.joinable()) {
-					t.detach();
-				}
-			}
-			catch (...) {
-				// Thread creation error handling
-			}
+			AsyncLoadCustomInjections();
 
 			info_msg = "Rop.CustomInjectReloading"_l;
 			show_info = true;
@@ -528,26 +513,7 @@ void Injector::RenderCustomInjectTab(bool& show_info, std::string& info_msg) {
 		std::string currentModTime = GetFileModifiedTime(injectionFilePath);
 		if (currentModTime != lastModifiedTime) {
 			needsReload = true;
-
-			try {
-				std::thread t([this]() {
-					try {
-						if (!isShuttingDown.load()) {
-							BackgroundReload();
-						}
-					}
-					catch (...) {
-						// Catch exceptions
-					}
-				});
-
-				if (t.joinable()) {
-					t.detach();
-				}
-			}
-			catch (...) {
-				// Thread creation error handling
-			}
+			AsyncLoadCustomInjections();
 		}
 	}
 }
@@ -633,9 +599,7 @@ void Injector::RenderCore() {
 		injectionFilePath = currentFilePath;
 		needsReload = true;
 		if (!isReloading.load()) {
-			std::thread([this]() {
-				BackgroundReload();
-			}).detach();
+			AsyncLoadCustomInjections();
 		}
 	}
 

--- a/CasioEmuMsvc/Gui/Injector.hpp
+++ b/CasioEmuMsvc/Gui/Injector.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -31,6 +32,7 @@ private:
 	std::vector<InjectorData> injectors;
 	std::vector<CustomInjection> customInjections;
 	std::mutex injectionMutex;
+	std::thread reloadThread;
 	bool needsReload;
 	std::atomic<bool> isReloading;
 	std::atomic<bool> isShuttingDown;


### PR DESCRIPTION
The crash was caused by a race condition where the `Injector` object was destroyed while a detached background thread (`BackgroundReload`) was still running. This led to a use-after-free when the thread attempted to lock `injectionMutex`.

This fix replaces the detached thread with a member `std::thread` variable (`reloadThread`). The `Injector` destructor now waits for this thread to join, ensuring that the object remains valid for the duration of the thread's execution. All manual thread spawning for reloading custom injections has been consolidated into `AsyncLoadCustomInjections`, which handles thread joining and creation safely.

This resolves the reported `EXCEPTION_ACCESS_VIOLATION_READ` in `mtx_do_lock`.

---
*PR created automatically by Jules for task [13657443328949502331](https://jules.google.com/task/13657443328949502331) started by @telecomadm1145*