### PR TITLE
Fix HwController crash with invalid IRQ index

### DIFF
--- a/CasioEmuMsvc/Gui/HwController.cpp
+++ b/CasioEmuMsvc/Gui/HwController.cpp
@@ -81,10 +81,12 @@ void HwController::RenderCore() {
 		m_emu->ModelDefinition.pd_value = pd;
 	}
 
-	static int irq = 0;
+	static int irq = 5;
 	ImGui::InputInt("##0d000721",&irq);
 	if (ImGui::Button("HwController.Interrupt"_lc)) {
-		m_emu->chipset.RaiseMaskable(irq);
+		if (irq >= 5 && irq < 64) {
+			m_emu->chipset.RaiseMaskable(irq);
+		}
 	}
 	if (ImGui::Button("HwController.HotReload"_lc)) {
 		m_emu->SetPaused(true);


### PR DESCRIPTION
The `HwController` debug interface allowed users to input an arbitrary interrupt index and trigger `RaiseMaskable`. The `RaiseMaskable` function asserts that the index is valid (between `INT_MASKABLE` (5) and `INT_SOFTWARE` (64)) and panics if it is not. Since the default value was `0`, clicking the "Interrupt" button immediately crashed the application.

This PR fixes the issue by:
1.  Initializing the `irq` input field to `5` (a valid default).
2.  Adding a conditional check to ensure `RaiseMaskable` is only called with a valid index.

---
*PR created automatically by Jules for task [4479480184076631121](https://jules.google.com/task/4479480184076631121) started by @telecomadm1145*