### PR TITLE
feat: discord rich presence + PR build check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Auto build and pre-release
 
 on:
-  pull_request:
-    branches: [ "stable" ]
   workflow_dispatch:
   push:
     branches: [ "stable" ]

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,44 @@
+name: PR Build Check
+
+on:
+  pull_request:
+    branches: [ "stable" ]
+
+env:
+  SOLUTION_FILE_PATH: .
+  BUILD_CONFIGURATION: Release
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    name: Windows (x64)
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - uses: microsoft/setup-msbuild@v2
+
+    - name: Restore NuGet packages
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=x64 ${{env.SOLUTION_FILE_PATH}}
+
+  build-linux:
+    runs-on: ubuntu-latest
+    name: Linux (x64)
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Build
+      run: |
+        chmod +x build-linux.sh
+        sudo DEBIAN_FRONTEND=noninteractive ./build-linux.sh -y

--- a/CasioEmuMsvc/CasioEmuMsvc.vcxproj
+++ b/CasioEmuMsvc/CasioEmuMsvc.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="ASan|Win32">
@@ -396,6 +396,7 @@
     <ClCompile Include="JitU8\JitU8.cpp" />
     <ClCompile Include="Gui\AddressWindow.cpp" />
     <ClCompile Include="casioemu.cpp" />
+    <ClCompile Include="DiscordRPC.cpp" />
     <ClCompile Include="Chipset\Chipset.cpp" />
     <ClCompile Include="Chipset\CPU.cpp" />
     <ClCompile Include="Chipset\CPUArithmetic.cpp" />
@@ -489,6 +490,7 @@
     <ClInclude Include="Chipset\MMU.hpp" />
     <ClInclude Include="Chipset\MMURegion.hpp" />
     <ClInclude Include="Config.hpp" />
+    <ClInclude Include="DiscordRPC.h" />
     <ClInclude Include="Containers\ConcurrentObject.h" />
     <ClInclude Include="Ext\LabelFile.h" />
     <ClInclude Include="Ext\RomPackage.h" />

--- a/CasioEmuMsvc/DiscordRPC.cpp
+++ b/CasioEmuMsvc/DiscordRPC.cpp
@@ -1,0 +1,404 @@
+#include "DiscordRPC.h"
+
+#ifndef DISABLE_DISCORD_RPC
+
+#include <cstring>
+#include <cstdio>
+#include <sstream>
+#include <cstdlib>
+
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#endif
+
+using namespace std;
+
+namespace discord_rpc {
+
+enum OpCode {
+	OP_HANDSHAKE = 0,
+	OP_FRAME = 1,
+	OP_CLOSE = 2,
+	OP_PING = 3,
+	OP_PONG = 4,
+};
+
+struct FrameHeader {
+	uint32_t opcode;
+	uint32_t length;
+};
+
+static string JsonEscape(const string& s) {
+	string result;
+	result.reserve(s.size() + 8);
+	for (char c : s) {
+		switch (c) {
+		case '"':  result += "\\\""; break;
+		case '\\': result += "\\\\"; break;
+		case '\n': result += "\\n"; break;
+		case '\r': result += "\\r"; break;
+		case '\t': result += "\\t"; break;
+		default:   result += c; break;
+		}
+	}
+	return result;
+}
+
+DiscordRPC::DiscordRPC(const string& client_id)
+	: m_client_id(client_id) {
+}
+
+DiscordRPC::~DiscordRPC() {
+	try {
+		Disconnect();
+	} catch (...) {}
+}
+
+bool DiscordRPC::IsConnected() const {
+	return m_connected.load();
+}
+
+bool DiscordRPC::Connect() {
+	lock_guard<mutex> lock(m_mutex);
+	if (m_connected)
+		return true;
+
+	if (!OpenPipe())
+		return false;
+
+	string handshake = BuildHandshakeJson();
+	if (!WriteFrame(OP_HANDSHAKE, handshake)) {
+		ClosePipe();
+		return false;
+	}
+
+	string response = ReadFrame();
+	if (response.empty()) {
+		ClosePipe();
+		return false;
+	}
+
+	m_connected = true;
+	m_reconnect_failures = 0;
+	printf("[discord rpc] connected\n");
+	return true;
+}
+
+void DiscordRPC::Disconnect() {
+	lock_guard<mutex> lock(m_mutex);
+	if (!m_connected)
+		return;
+	m_connected = false;
+	ClosePipe();
+	printf("[discord rpc] disconnected\n");
+}
+
+bool DiscordRPC::TryReconnect() {
+	if (m_connected)
+		return true;
+
+	auto now = chrono::steady_clock::now();
+	int backoff_seconds = 60 * (1 << min(m_reconnect_failures, 4));
+	if (now - m_last_reconnect_attempt < chrono::seconds(backoff_seconds))
+		return false;
+
+	m_last_reconnect_attempt = now;
+
+	if (Connect())
+		return true;
+
+	m_reconnect_failures++;
+	return false;
+}
+
+void DiscordRPC::UpdatePresence(const RichPresence& presence) {
+	lock_guard<mutex> lock(m_mutex);
+	if (!m_connected)
+		return;
+
+	string json = BuildPresenceJson(presence, m_nonce++);
+	if (!WriteFrame(OP_FRAME, json)) {
+		m_connected = false;
+		ClosePipe();
+		printf("[discord rpc] lost connection\n");
+	}
+}
+
+void DiscordRPC::ClearPresence() {
+	lock_guard<mutex> lock(m_mutex);
+	if (!m_connected)
+		return;
+
+	ostringstream ss;
+	ss << "{\"cmd\":\"SET_ACTIVITY\",\"args\":{\"pid\":" 
+#ifdef _WIN32
+	   << GetCurrentProcessId()
+#else
+	   << getpid()
+#endif
+	   << ",\"activity\":null},\"nonce\":\"" << m_nonce++ << "\"}";
+
+	if (!WriteFrame(OP_FRAME, ss.str())) {
+		m_connected = false;
+		ClosePipe();
+	}
+}
+
+string DiscordRPC::BuildHandshakeJson() {
+	return "{\"v\":1,\"client_id\":\"" + m_client_id + "\"}";
+}
+
+string DiscordRPC::BuildPresenceJson(const RichPresence& presence, int nonce) {
+	ostringstream ss;
+	ss << "{\"cmd\":\"SET_ACTIVITY\",\"args\":{\"pid\":";
+#ifdef _WIN32
+	ss << GetCurrentProcessId();
+#else
+	ss << getpid();
+#endif
+	ss << ",\"activity\":{";
+	
+	bool first = true;
+	
+	if (!presence.state.empty()) {
+		ss << "\"state\":\"" << JsonEscape(presence.state) << "\"";
+		first = false;
+	}
+	if (!presence.details.empty()) {
+		if (!first) ss << ",";
+		ss << "\"details\":\"" << JsonEscape(presence.details) << "\"";
+		first = false;
+	}
+	
+	if (presence.startTimestamp != 0 || presence.endTimestamp != 0) {
+		if (!first) ss << ",";
+		ss << "\"timestamps\":{";
+		bool tfirst = true;
+		if (presence.startTimestamp != 0) {
+			ss << "\"start\":" << presence.startTimestamp;
+			tfirst = false;
+		}
+		if (presence.endTimestamp != 0) {
+			if (!tfirst) ss << ",";
+			ss << "\"end\":" << presence.endTimestamp;
+		}
+		ss << "}";
+		first = false;
+	}
+	
+	bool hasAssets = !presence.largeImageKey.empty() || !presence.smallImageKey.empty();
+	if (hasAssets) {
+		if (!first) ss << ",";
+		ss << "\"assets\":{";
+		bool afirst = true;
+		if (!presence.largeImageKey.empty()) {
+			ss << "\"large_image\":\"" << JsonEscape(presence.largeImageKey) << "\"";
+			afirst = false;
+			if (!presence.largeImageText.empty()) {
+				ss << ",\"large_text\":\"" << JsonEscape(presence.largeImageText) << "\"";
+			}
+		}
+		if (!presence.smallImageKey.empty()) {
+			if (!afirst) ss << ",";
+			ss << "\"small_image\":\"" << JsonEscape(presence.smallImageKey) << "\"";
+			if (!presence.smallImageText.empty()) {
+				ss << ",\"small_text\":\"" << JsonEscape(presence.smallImageText) << "\"";
+			}
+		}
+		ss << "}";
+		first = false;
+	}
+	
+	ss << "}},\"nonce\":\"" << nonce << "\"}";
+	return ss.str();
+}
+
+#ifdef _WIN32
+
+bool DiscordRPC::OpenPipe() {
+	for (int i = 0; i < 10; i++) {
+		char pipeName[64];
+		snprintf(pipeName, sizeof(pipeName), "\\\\.\\pipe\\discord-ipc-%d", i);
+
+		m_pipe = CreateFileA(
+			pipeName,
+			GENERIC_READ | GENERIC_WRITE,
+			0, NULL,
+			OPEN_EXISTING,
+			0, NULL);
+
+		if (m_pipe != INVALID_HANDLE_VALUE)
+			return true;
+	}
+	m_pipe = nullptr;
+	return false;
+}
+
+void DiscordRPC::ClosePipe() {
+	if (m_pipe && m_pipe != INVALID_HANDLE_VALUE)
+		CloseHandle(m_pipe);
+	m_pipe = nullptr;
+}
+
+bool DiscordRPC::WriteFrame(int opcode, const string& json) {
+	if (!m_pipe || m_pipe == INVALID_HANDLE_VALUE)
+		return false;
+
+	FrameHeader header;
+	header.opcode = (uint32_t)opcode;
+	header.length = (uint32_t)json.size();
+
+	DWORD written;
+	if (!WriteFile(m_pipe, &header, sizeof(header), &written, NULL))
+		return false;
+	if (!WriteFile(m_pipe, json.c_str(), (DWORD)json.size(), &written, NULL))
+		return false;
+
+	return true;
+}
+
+string DiscordRPC::ReadFrame() {
+	if (!m_pipe || m_pipe == INVALID_HANDLE_VALUE)
+		return "";
+
+	FrameHeader header;
+	DWORD bytesRead;
+	if (!ReadFile(m_pipe, &header, sizeof(header), &bytesRead, NULL))
+		return "";
+	if (bytesRead != sizeof(header))
+		return "";
+	if (header.length > 65536)
+		return "";
+
+	string data(header.length, '\0');
+	if (!ReadFile(m_pipe, &data[0], header.length, &bytesRead, NULL))
+		return "";
+	if (bytesRead != header.length)
+		return "";
+
+	return data;
+}
+
+#else
+
+static string GetDiscordSocketPath(int pipeNum) {
+	string base;
+
+	const char* xdg = getenv("XDG_RUNTIME_DIR");
+	if (xdg) {
+		base = xdg;
+	} else {
+		const char* tmpdir = getenv("TMPDIR");
+		base = tmpdir ? tmpdir : "/tmp";
+	}
+
+	char path[256];
+	snprintf(path, sizeof(path), "%s/discord-ipc-%d", base.c_str(), pipeNum);
+	return path;
+}
+
+bool DiscordRPC::OpenPipe() {
+	for (int i = 0; i < 10; i++) {
+		string socketPath = GetDiscordSocketPath(i);
+
+		m_pipe_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+		if (m_pipe_fd < 0)
+			continue;
+
+		struct sockaddr_un addr;
+		memset(&addr, 0, sizeof(addr));
+		addr.sun_family = AF_UNIX;
+		strncpy(addr.sun_path, socketPath.c_str(), sizeof(addr.sun_path) - 1);
+
+		if (connect(m_pipe_fd, (struct sockaddr*)&addr, sizeof(addr)) == 0)
+			return true;
+
+		close(m_pipe_fd);
+		m_pipe_fd = -1;
+	}
+
+	// snap/flatpak paths
+	const char* xdg = getenv("XDG_RUNTIME_DIR");
+	if (xdg) {
+		const char* appDirs[] = {
+			"app/com.discordapp.Discord",
+			"snap.discord",
+		};
+		for (const char* appDir : appDirs) {
+			for (int i = 0; i < 10; i++) {
+				char socketPath[512];
+				snprintf(socketPath, sizeof(socketPath), "%s/%s/discord-ipc-%d", xdg, appDir, i);
+
+				m_pipe_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+				if (m_pipe_fd < 0) continue;
+
+				struct sockaddr_un addr;
+				memset(&addr, 0, sizeof(addr));
+				addr.sun_family = AF_UNIX;
+				strncpy(addr.sun_path, socketPath, sizeof(addr.sun_path) - 1);
+
+				if (connect(m_pipe_fd, (struct sockaddr*)&addr, sizeof(addr)) == 0)
+					return true;
+
+				close(m_pipe_fd);
+				m_pipe_fd = -1;
+			}
+		}
+	}
+
+	return false;
+}
+
+void DiscordRPC::ClosePipe() {
+	if (m_pipe_fd >= 0)
+		close(m_pipe_fd);
+	m_pipe_fd = -1;
+}
+
+bool DiscordRPC::WriteFrame(int opcode, const string& json) {
+	if (m_pipe_fd < 0)
+		return false;
+
+	FrameHeader header;
+	header.opcode = (uint32_t)opcode;
+	header.length = (uint32_t)json.size();
+
+	if (write(m_pipe_fd, &header, sizeof(header)) != sizeof(header))
+		return false;
+	if (write(m_pipe_fd, json.c_str(), json.size()) != (ssize_t)json.size())
+		return false;
+
+	return true;
+}
+
+string DiscordRPC::ReadFrame() {
+	if (m_pipe_fd < 0)
+		return "";
+
+	FrameHeader header;
+	if (read(m_pipe_fd, &header, sizeof(header)) != sizeof(header))
+		return "";
+	if (header.length > 65536)
+		return "";
+
+	string data(header.length, '\0');
+	ssize_t total = 0;
+	while (total < (ssize_t)header.length) {
+		ssize_t r = read(m_pipe_fd, &data[total], header.length - total);
+		if (r <= 0)
+			return "";
+		total += r;
+	}
+
+	return data;
+}
+
+#endif
+
+} // namespace discord_rpc
+
+#endif

--- a/CasioEmuMsvc/DiscordRPC.h
+++ b/CasioEmuMsvc/DiscordRPC.h
@@ -1,0 +1,100 @@
+#pragma once
+
+// -DDISABLE_DISCORD_RPC to disable at compile time (CI/CD, headless builds)
+
+#ifndef DISABLE_DISCORD_RPC
+
+#include <string>
+#include <cstdint>
+#include <thread>
+#include <atomic>
+#include <mutex>
+#include <chrono>
+
+using namespace std;
+
+namespace discord_rpc {
+
+struct RichPresence {
+	string state;
+	string details;
+	string largeImageKey;
+	string largeImageText;
+	string smallImageKey;
+	string smallImageText;
+	int64_t startTimestamp = 0;
+	int64_t endTimestamp = 0;
+};
+
+class DiscordRPC {
+public:
+	explicit DiscordRPC(const string& client_id);
+	~DiscordRPC();
+
+	bool Connect();
+	void Disconnect();
+	void UpdatePresence(const RichPresence& presence);
+	void ClearPresence();
+	bool IsConnected() const;
+	bool TryReconnect();
+
+private:
+	bool OpenPipe();
+	void ClosePipe();
+	bool WriteFrame(int opcode, const string& json);
+	string ReadFrame();
+	string BuildHandshakeJson();
+	string BuildPresenceJson(const RichPresence& presence, int nonce);
+
+	string m_client_id;
+	atomic<bool> m_connected{false};
+	int m_nonce = 1;
+	mutex m_mutex;
+
+	chrono::steady_clock::time_point m_last_reconnect_attempt{};
+	int m_reconnect_failures = 0;
+
+#ifdef _WIN32
+	void* m_pipe = nullptr;
+#else
+	int m_pipe_fd = -1;
+#endif
+};
+
+} // namespace discord_rpc
+
+#else
+
+#include <string>
+#include <cstdint>
+
+using namespace std;
+
+namespace discord_rpc {
+
+struct RichPresence {
+	string state;
+	string details;
+	string largeImageKey;
+	string largeImageText;
+	string smallImageKey;
+	string smallImageText;
+	int64_t startTimestamp = 0;
+	int64_t endTimestamp = 0;
+};
+
+class DiscordRPC {
+public:
+	explicit DiscordRPC(const string&) {}
+	~DiscordRPC() = default;
+	bool Connect() { return false; }
+	void Disconnect() {}
+	void UpdatePresence(const RichPresence&) {}
+	void ClearPresence() {}
+	bool IsConnected() const { return false; }
+	bool TryReconnect() { return false; }
+};
+
+} // namespace discord_rpc
+
+#endif

--- a/CasioEmuMsvc/DiscordRPC.h
+++ b/CasioEmuMsvc/DiscordRPC.h
@@ -11,24 +11,22 @@
 #include <mutex>
 #include <chrono>
 
-using namespace std;
-
 namespace discord_rpc {
 
 struct RichPresence {
-	string state;
-	string details;
-	string largeImageKey;
-	string largeImageText;
-	string smallImageKey;
-	string smallImageText;
+	std::string state;
+	std::string details;
+	std::string largeImageKey;
+	std::string largeImageText;
+	std::string smallImageKey;
+	std::string smallImageText;
 	int64_t startTimestamp = 0;
 	int64_t endTimestamp = 0;
 };
 
 class DiscordRPC {
 public:
-	explicit DiscordRPC(const string& client_id);
+	explicit DiscordRPC(const std::string& client_id);
 	~DiscordRPC();
 
 	bool Connect();
@@ -41,17 +39,17 @@ public:
 private:
 	bool OpenPipe();
 	void ClosePipe();
-	bool WriteFrame(int opcode, const string& json);
-	string ReadFrame();
-	string BuildHandshakeJson();
-	string BuildPresenceJson(const RichPresence& presence, int nonce);
+	bool WriteFrame(int opcode, const std::string& json);
+	std::string ReadFrame();
+	std::string BuildHandshakeJson();
+	std::string BuildPresenceJson(const RichPresence& presence, int nonce);
 
-	string m_client_id;
-	atomic<bool> m_connected{false};
+	std::string m_client_id;
+	std::atomic<bool> m_connected{false};
 	int m_nonce = 1;
-	mutex m_mutex;
+	std::mutex m_mutex;
 
-	chrono::steady_clock::time_point m_last_reconnect_attempt{};
+	std::chrono::steady_clock::time_point m_last_reconnect_attempt{};
 	int m_reconnect_failures = 0;
 
 #ifdef _WIN32
@@ -68,24 +66,22 @@ private:
 #include <string>
 #include <cstdint>
 
-using namespace std;
-
 namespace discord_rpc {
 
 struct RichPresence {
-	string state;
-	string details;
-	string largeImageKey;
-	string largeImageText;
-	string smallImageKey;
-	string smallImageText;
+	std::string state;
+	std::string details;
+	std::string largeImageKey;
+	std::string largeImageText;
+	std::string smallImageKey;
+	std::string smallImageText;
 	int64_t startTimestamp = 0;
 	int64_t endTimestamp = 0;
 };
 
 class DiscordRPC {
 public:
-	explicit DiscordRPC(const string&) {}
+	explicit DiscordRPC(const std::string&) {}
 	~DiscordRPC() = default;
 	bool Connect() { return false; }
 	void Disconnect() {}

--- a/CasioEmuMsvc/casioemu.cpp
+++ b/CasioEmuMsvc/casioemu.cpp
@@ -1,4 +1,5 @@
-﻿#include "Config.hpp"
+#include "Config.hpp"
+#include "DiscordRPC.h"
 #include "Ui.hpp"
 #include "imgui_impl_sdl2.h"
 
@@ -48,6 +49,12 @@ using namespace casioemu;
 SDL_Surface* background;
 SDL_Texture* bg_txt;
 bool low_perf_ext = false;
+
+// discord rich presence — set your app id at https://discord.com/developers/applications
+static const char* DISCORD_APP_ID = "1492135114086420600";
+static discord_rpc::DiscordRPC* g_discord = nullptr;
+static Uint32 g_discord_last_update = 0;
+static int64_t g_discord_start_time = 0;
 
 int main(int argc, char* argv[]) {
 #ifdef _WIN32
@@ -113,6 +120,20 @@ int main(int argc, char* argv[]) {
 	low_perf_ext = !argv_map["low_perf_ext"].empty();
 	Emulator emulator(argv_map);
 	m_emu = &emulator;
+
+	g_discord_start_time = (int64_t)std::time(nullptr);
+	g_discord = new discord_rpc::DiscordRPC(DISCORD_APP_ID);
+	try {
+		if (g_discord->Connect()) {
+			discord_rpc::RichPresence rp;
+			rp.details = "CasioEmuMsvc";
+			rp.state = "Emulating " + std::string(emulator.ModelDefinition.model_name);
+			rp.startTimestamp = g_discord_start_time;
+			rp.largeImageKey = "casio_logo";
+			rp.largeImageText = "CasioEmuMsvc - Calculator Emulator";
+			g_discord->UpdatePresence(rp);
+		}
+	} catch (...) {}
 
 	// static std::atomic<bool> running(true);
 
@@ -345,6 +366,25 @@ int main(int argc, char* argv[]) {
 					ThemeManager::Instance().ClearBgReloadRequest();
 				}
 			}
+			if (g_discord) {
+				Uint32 now_ticks = SDL_GetTicks();
+				if (now_ticks - g_discord_last_update > 30000) {
+					g_discord_last_update = now_ticks;
+					if (!g_discord->IsConnected())
+						g_discord->TryReconnect();
+					if (g_discord->IsConnected()) {
+						discord_rpc::RichPresence rp;
+						rp.details = "CasioEmuMsvc";
+						rp.state = "Emulating " + std::string(emulator.ModelDefinition.model_name);
+						if (emulator.GetPaused())
+							rp.state += " (Paused)";
+						rp.startTimestamp = g_discord_start_time;
+						rp.largeImageKey = "casio_logo";
+						rp.largeImageText = "CasioEmuMsvc - Calculator Emulator";
+						g_discord->UpdatePresence(rp);
+					}
+				}
+			}
 			while (SDL_PollEvent(&event)) {
 				if (event.type != frame_event)
 					goto hld;
@@ -549,6 +589,13 @@ int main(int argc, char* argv[]) {
 	running = false;
 	if (t3.joinable()) {
 		t3.join();
+	}
+
+	if (g_discord) {
+		g_discord->ClearPresence();
+		g_discord->Disconnect();
+		delete g_discord;
+		g_discord = nullptr;
 	}
 	if (bg_txt) {
 		SDL_DestroyTexture(bg_txt);


### PR DESCRIPTION
## Discord Rich Presence
- lightweight RPC client via direct IPC (no external dependencies)
- shows current model name and elapsed time on Discord
- auto-reconnect with exponential backoff
- non-fatal — emulator works fine without Discord
- cross-platform: Windows (Named Pipe), Linux/macOS (Unix Socket)
- compile-time disable via `-DDISABLE_DISCORD_RPC` for CI/CD

### Files
- `DiscordRPC.h` / `DiscordRPC.cpp` — RPC implementation
- `casioemu.cpp` — integration into main loop
- `CasioEmuMsvc.vcxproj` — MSVC project update

## CI
- added `pr-check.yml` — lightweight build verification for PRs (Windows x64 + Linux)
- removed `pull_request` trigger from `build.yml` to avoid duplicate runs
