### PR TITLE
Localize Snapshot window

### DIFF
--- a/CasioEmuMsvc/Gui/SnapshotWindow.cpp
+++ b/CasioEmuMsvc/Gui/SnapshotWindow.cpp
@@ -10,6 +10,7 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include "Localization.h"
 
 // ============================================================
 // Helpers
@@ -33,7 +34,7 @@ static std::string FormatTimestamp(int64_t ts) {
 // ============================================================
 
 SnapshotWindow::SnapshotWindow()
-    : UIWindow("Snapshots") {
+    : UIWindow("SnapshotWindow.Title"_lc) {
     inital_size = ImVec2(880, 560);
     memset(m_LabelBuf, 0, sizeof(m_LabelBuf));
 }
@@ -82,10 +83,10 @@ void SnapshotWindow::RenderToolbar() {
 
     // --- Save button ---
     if (!hasEmu) ImGui::BeginDisabled();
-    if (ImGui::Button("Save Snapshot")) {
+    if (ImGui::Button("SnapshotWindow.Save"_lc)) {
         try {
             std::string lbl(m_LabelBuf);
-            if (lbl.empty()) lbl = "Snapshot " + std::to_string(m_Manager.Nodes.size() + 1);
+            if (lbl.empty()) lbl = std::string("SnapshotWindow.SnapshotPrefix"_lc) + std::to_string(m_Manager.Nodes.size() + 1);
             uint32_t newId = m_Manager.SaveSnapshot(*::m_emu, m_SelectedId, lbl);
             m_SelectedId = newId;
             TryLoadPreview(newId);
@@ -100,7 +101,7 @@ void SnapshotWindow::RenderToolbar() {
     // --- Load button ---
     bool hasSelected = (m_SelectedId != 0 && hasEmu);
     if (!hasSelected) ImGui::BeginDisabled();
-    if (ImGui::Button("Load")) {
+    if (ImGui::Button("SnapshotWindow.Load"_lc)) {
         try {
             m_Manager.LoadSnapshot(*::m_emu, m_SelectedId);
         } catch (const std::exception& e) {
@@ -112,7 +113,7 @@ void SnapshotWindow::RenderToolbar() {
 
     // --- Delete button ---
     if (!hasSelected) ImGui::BeginDisabled();
-    if (ImGui::Button("Delete")) {
+    if (ImGui::Button("SnapshotWindow.Delete"_lc)) {
         if (m_SelectedId != 0) {
             m_Manager.DeleteNode(m_SelectedId);
             m_SelectedId = 0;
@@ -127,7 +128,7 @@ void SnapshotWindow::RenderToolbar() {
 
     // --- Export selected ---
     if (!hasSelected) ImGui::BeginDisabled();
-    if (ImGui::Button("Export Node")) {
+    if (ImGui::Button("SnapshotWindow.ExportNode"_lc)) {
         if (m_SelectedId != 0) {
             uint32_t exportId = m_SelectedId;
             SystemDialogs::SaveFileDialog("snapshot.snapshot", [this, exportId](std::filesystem::path path) {
@@ -141,7 +142,7 @@ void SnapshotWindow::RenderToolbar() {
 
     // --- Export subtree ---
     if (!hasSelected) ImGui::BeginDisabled();
-    if (ImGui::Button("Export Subtree")) {
+    if (ImGui::Button("SnapshotWindow.ExportSubtree"_lc)) {
         if (m_SelectedId != 0) {
             uint32_t exportId = m_SelectedId;
             SystemDialogs::SaveFileDialog("snapshot.snapshot", [this, exportId](std::filesystem::path path) {
@@ -154,7 +155,7 @@ void SnapshotWindow::RenderToolbar() {
     ImGui::SameLine();
 
     // --- Export all ---
-    if (ImGui::Button("Export All")) {
+    if (ImGui::Button("SnapshotWindow.ExportAll"_lc)) {
         SystemDialogs::SaveFileDialog("snapshots.snapshot", [this](std::filesystem::path path) {
             try { m_Manager.ExportAll(path); }
             catch (const std::exception& e) { ShowError(e.what()); }
@@ -163,7 +164,7 @@ void SnapshotWindow::RenderToolbar() {
     ImGui::SameLine();
 
     // --- Import ---
-    if (ImGui::Button("Import...")) {
+    if (ImGui::Button("SnapshotWindow.Import"_lc)) {
         SystemDialogs::OpenFileDialog([this](std::filesystem::path path) {
             try { m_Manager.ImportFromFile(path); }
             catch (const std::exception& e) { ShowError(e.what()); }
@@ -174,9 +175,9 @@ void SnapshotWindow::RenderToolbar() {
 
     // --- Label input ---
     ImGui::SetNextItemWidth(320);
-    ImGui::InputText("Label##snap_label", m_LabelBuf, sizeof(m_LabelBuf));
+    ImGui::InputText("SnapshotWindow.Label"_lc, m_LabelBuf, sizeof(m_LabelBuf));
     ImGui::SameLine();
-    ImGui::TextDisabled("(label for next saved snapshot)");
+    ImGui::TextDisabled("%s", "SnapshotWindow.LabelHint"_lc);
     ImGui::Separator();
 }
 
@@ -194,7 +195,7 @@ void SnapshotWindow::RenderTreeNode(uint32_t parentId, int depth) {
             if (c.ParentId == node.Id && c.Id != node.Id) { hasChildren = true; break; }
 
         std::string displayLabel = node.Label.empty()
-            ? ("Node " + std::to_string(node.Id))
+            ? (std::string("SnapshotWindow.NodePrefix"_lc) + std::to_string(node.Id))
             : node.Label;
         displayLabel += "  [" + FormatTimestamp(node.Timestamp) + "]";
 
@@ -213,11 +214,11 @@ void SnapshotWindow::RenderTreeNode(uint32_t parentId, int depth) {
 
         // Right-click context menu
         if (ImGui::BeginPopupContextItem()) {
-            if (ImGui::MenuItem("Save child snapshot here")) {
+            if (ImGui::MenuItem("SnapshotWindow.SaveChild"_lc)) {
                 if (::m_emu) {
                     try {
                         std::string lbl(m_LabelBuf);
-                        if (lbl.empty()) lbl = "Child of " + std::to_string(node.Id);
+                        if (lbl.empty()) lbl = std::string("SnapshotWindow.ChildOf"_lc) + std::to_string(node.Id);
                         uint32_t newId = m_Manager.SaveSnapshot(*::m_emu, node.Id, lbl);
                         m_SelectedId = newId;
                         TryLoadPreview(newId);
@@ -225,14 +226,14 @@ void SnapshotWindow::RenderTreeNode(uint32_t parentId, int depth) {
                     } catch (const std::exception& e) { ShowError(e.what()); }
                 }
             }
-            if (ImGui::MenuItem("Load this snapshot")) {
+            if (ImGui::MenuItem("SnapshotWindow.LoadThis"_lc)) {
                 if (::m_emu) {
                     try { m_Manager.LoadSnapshot(*::m_emu, node.Id); }
                     catch (const std::exception& e) { ShowError(e.what()); }
                 }
             }
             ImGui::Separator();
-            if (ImGui::MenuItem("Delete (+ children)")) {
+            if (ImGui::MenuItem("SnapshotWindow.DeleteWithChildren"_lc)) {
                 m_Manager.DeleteNode(node.Id);
                 if (m_SelectedId == node.Id) { m_SelectedId = 0; m_Preview.Free(); }
                 ImGui::EndPopup();
@@ -252,7 +253,7 @@ void SnapshotWindow::RenderTreeNode(uint32_t parentId, int depth) {
 void SnapshotWindow::RenderTree() {
     ImGui::BeginChild("##snap_tree", ImVec2(380, 0), true);
     if (m_Manager.Nodes.empty()) {
-        ImGui::TextDisabled("No snapshots yet.\nUse 'Save Snapshot' to create one.");
+        ImGui::TextDisabled("%s", "SnapshotWindow.NoSnapshots"_lc);
     } else {
         RenderTreeNode(0, 0);
     }
@@ -272,7 +273,7 @@ void SnapshotWindow::RenderDetails() {
         if (n.Id == m_SelectedId) { sel = &n; break; }
 
     if (!sel) {
-        ImGui::TextDisabled("Select a snapshot to see details.");
+        ImGui::TextDisabled("%s", "SnapshotWindow.SelectToSeeDetails"_lc);
         ImGui::EndChild();
         return;
     }
@@ -287,19 +288,19 @@ void SnapshotWindow::RenderDetails() {
         ImGui::Image(reinterpret_cast<ImTextureID>(m_Preview.Tex),
                      ImVec2(imgW * scale, imgH * scale));
     } else {
-        ImGui::TextDisabled("[No preview]");
+        ImGui::TextDisabled("%s", "SnapshotWindow.NoPreview"_lc);
     }
 
     ImGui::Separator();
 
-    ImGui::Text("ID:        %u", sel->Id);
-    ImGui::Text("Parent ID: %u", sel->ParentId);
-    ImGui::Text("Label:     %s", sel->Label.c_str());
-    ImGui::Text("Saved:     %s", FormatTimestamp(sel->Timestamp).c_str());
-    ImGui::Text("State:     %zu bytes (compressed %zu)",
+    ImGui::Text("SnapshotWindow.ID"_lc, sel->Id);
+    ImGui::Text("SnapshotWindow.ParentID"_lc, sel->ParentId);
+    ImGui::Text("SnapshotWindow.LabelFmt"_lc, sel->Label.c_str());
+    ImGui::Text("SnapshotWindow.SavedFmt"_lc, FormatTimestamp(sel->Timestamp).c_str());
+    ImGui::Text("SnapshotWindow.StateFmt"_lc,
                 static_cast<size_t>(sel->UncompressedStateSize),
                 sel->CompressedState.size());
-    ImGui::Text("Preview:   %zu bytes", sel->PreviewPng.size());
+    ImGui::Text("SnapshotWindow.PreviewFmt"_lc, sel->PreviewPng.size());
 
     ImGui::EndChild();
 }
@@ -313,12 +314,12 @@ void SnapshotWindow::RenderCore() {
 
     // Error popup
     if (m_ShowError) {
-        ImGui::OpenPopup("Snapshot Error");
+        ImGui::OpenPopup("SnapshotWindow.ErrorTitle"_lc);
         m_ShowError = false;
     }
-    if (ImGui::BeginPopupModal("Snapshot Error", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+    if (ImGui::BeginPopupModal("SnapshotWindow.ErrorTitle"_lc, nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
         ImGui::TextWrapped("%s", m_ErrorMsg.c_str());
-        if (ImGui::Button("OK", ImVec2(120, 0))) ImGui::CloseCurrentPopup();
+        if (ImGui::Button("Button.Positive"_lc, ImVec2(120, 0))) ImGui::CloseCurrentPopup();
         ImGui::EndPopup();
     }
 

--- a/CasioEmuMsvc/locales/en_US.lc
+++ b/CasioEmuMsvc/locales/en_US.lc
@@ -206,4 +206,31 @@ BP.SPHint=SP
 
 DiscordRPC.ChoosingModel=Choosing a model...
 
+SnapshotWindow.Title=Snapshots
+SnapshotWindow.Save=Save Snapshot
+SnapshotWindow.SnapshotPrefix=Snapshot
+SnapshotWindow.Load=Load
+SnapshotWindow.Delete=Delete
+SnapshotWindow.ExportNode=Export Node
+SnapshotWindow.ExportSubtree=Export Subtree
+SnapshotWindow.ExportAll=Export All
+SnapshotWindow.Import=Import...
+SnapshotWindow.Label=Label
+SnapshotWindow.LabelHint=(label for next saved snapshot)
+SnapshotWindow.NodePrefix=Node
+SnapshotWindow.SaveChild=Save child snapshot here
+SnapshotWindow.ChildOf=Child of
+SnapshotWindow.LoadThis=Load this snapshot
+SnapshotWindow.DeleteWithChildren=Delete (+ children)
+SnapshotWindow.NoSnapshots=No snapshots yet.\nUse 'Save Snapshot' to create one.
+SnapshotWindow.SelectToSeeDetails=Select a snapshot to see details.
+SnapshotWindow.NoPreview=[No preview]
+SnapshotWindow.ID=ID:        %u
+SnapshotWindow.ParentID=Parent ID: %u
+SnapshotWindow.LabelFmt=Label:     %s
+SnapshotWindow.SavedFmt=Saved:     %s
+SnapshotWindow.StateFmt=State:     %zu bytes (compressed %zu)
+SnapshotWindow.PreviewFmt=Preview:   %zu bytes
+SnapshotWindow.ErrorTitle=Snapshot Error
+
 placeholder2=a)"

--- a/CasioEmuMsvc/locales/vi_VN.lc
+++ b/CasioEmuMsvc/locales/vi_VN.lc
@@ -207,4 +207,31 @@ BP.SPHint=SP
 
 DiscordRPC.ChoosingModel=Đang chọn model...
 
+SnapshotWindow.Title=Ảnh chụp (Snapshot)
+SnapshotWindow.Save=Lưu Snapshot
+SnapshotWindow.SnapshotPrefix=Snapshot
+SnapshotWindow.Load=Tải
+SnapshotWindow.Delete=Xóa
+SnapshotWindow.ExportNode=Xuất Node
+SnapshotWindow.ExportSubtree=Xuất Cây con
+SnapshotWindow.ExportAll=Xuất Tất cả
+SnapshotWindow.Import=Nhập...
+SnapshotWindow.Label=Nhãn
+SnapshotWindow.LabelHint=(nhãn cho snapshot tiếp theo)
+SnapshotWindow.NodePrefix=Node
+SnapshotWindow.SaveChild=Lưu snapshot con ở đây
+SnapshotWindow.ChildOf=Con của
+SnapshotWindow.LoadThis=Tải snapshot này
+SnapshotWindow.DeleteWithChildren=Xóa (+ các con)
+SnapshotWindow.NoSnapshots=Chưa có snapshot nào.\nDùng 'Lưu Snapshot' để tạo.
+SnapshotWindow.SelectToSeeDetails=Chọn một snapshot để xem chi tiết.
+SnapshotWindow.NoPreview=[Không có bản xem trước]
+SnapshotWindow.ID=ID:        %u
+SnapshotWindow.ParentID=ID Cha:    %u
+SnapshotWindow.LabelFmt=Nhãn:      %s
+SnapshotWindow.SavedFmt=Đã lưu:    %s
+SnapshotWindow.StateFmt=Trạng thái: %zu byte (đã nén %zu)
+SnapshotWindow.PreviewFmt=Xem trước: %zu byte
+SnapshotWindow.ErrorTitle=Lỗi Snapshot
+
 placeholder2=a)"

--- a/CasioEmuMsvc/locales/zh_CN.lc
+++ b/CasioEmuMsvc/locales/zh_CN.lc
@@ -206,4 +206,31 @@ BP.SPHint=SP
 
 DiscordRPC.ChoosingModel=正在选择机型...
 
+SnapshotWindow.Title=快照
+SnapshotWindow.Save=保存快照
+SnapshotWindow.SnapshotPrefix=快照
+SnapshotWindow.Load=加载
+SnapshotWindow.Delete=删除
+SnapshotWindow.ExportNode=导出节点
+SnapshotWindow.ExportSubtree=导出子树
+SnapshotWindow.ExportAll=导出全部
+SnapshotWindow.Import=导入...
+SnapshotWindow.Label=标签
+SnapshotWindow.LabelHint=(下一个保存快照的标签)
+SnapshotWindow.NodePrefix=节点
+SnapshotWindow.SaveChild=在此保存子快照
+SnapshotWindow.ChildOf=子节点
+SnapshotWindow.LoadThis=加载此快照
+SnapshotWindow.DeleteWithChildren=删除 (+ 子节点)
+SnapshotWindow.NoSnapshots=暂无快照。\n使用“保存快照”来创建一个。
+SnapshotWindow.SelectToSeeDetails=选择一个快照查看详情。
+SnapshotWindow.NoPreview=[无预览]
+SnapshotWindow.ID=ID:        %u
+SnapshotWindow.ParentID=父 ID:      %u
+SnapshotWindow.LabelFmt=标签:      %s
+SnapshotWindow.SavedFmt=保存时间:   %s
+SnapshotWindow.StateFmt=状态:      %zu 字节 (压缩后 %zu)
+SnapshotWindow.PreviewFmt=预览:      %zu 字节
+SnapshotWindow.ErrorTitle=快照错误
+
 placeholder2=a)"


### PR DESCRIPTION
I extracted the hardcoded English strings in `CasioEmuMsvc/Gui/SnapshotWindow.cpp` and added them to `en_US.lc`. Then, I added translations for Chinese and Vietnamese to `zh_CN.lc` and `vi_VN.lc` respectively. Finally, I updated `SnapshotWindow.cpp` to include `Localization.h` and use the `_lc` literal for all the strings.

---
*PR created automatically by Jules for task [2744912763494257005](https://jules.google.com/task/2744912763494257005) started by @telecomadm1145*