### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-08 - Fix Command Injection in SysDialog.cpp
+**Vulnerability:** The `SystemDialogs::SaveFileDialog` method concatenated an unescaped, user-controlled `preferred_name` string directly into a shell command for `zenity` and `kdialog` that was executed via `popen`, making it vulnerable to command injection.
+**Learning:** File dialog wrappers or other external commands using `system()` or `popen()` must sanitize or strictly escape string parameters (e.g. by wrapping them in single quotes and safely managing nested single quotes).
+**Prevention:** Implement and use a safe `escape_shell_arg` function for all shell command concatenations, or prefer native APIs over invoking external binaries via the shell.

--- a/CasioEmuMsvc/Ext/SysDialog.cpp
+++ b/CasioEmuMsvc/Ext/SysDialog.cpp
@@ -389,6 +389,19 @@ bool command_exists(const char* cmd) {
     return system(check_cmd.c_str()) == 0;
 }
 
+std::string escape_shell_arg(const std::string& arg) {
+    std::string escaped = "'";
+    for (char c : arg) {
+        if (c == '\'') {
+            escaped += "'\\''";
+        } else {
+            escaped += c;
+        }
+    }
+    escaped += "'";
+    return escaped;
+}
+
 std::string exec_and_get_output(const char* cmd) {
     std::array<char, 128> buffer;
     std::string result;
@@ -436,10 +449,11 @@ void SystemDialogs::OpenFileDialog(std::function<void(std::filesystem::path)> ca
 
 void SystemDialogs::SaveFileDialog(std::string preferred_name, std::function<void(std::filesystem::path)> callback) {
     std::string cmd;
+    std::string safe_preferred_name = escape_shell_arg(preferred_name);
     if (command_exists("zenity")) {
-        cmd = "zenity --file-selection --save --confirm-overwrite --filename=\"" + preferred_name + "\"";
+        cmd = "zenity --file-selection --save --confirm-overwrite --filename=" + safe_preferred_name;
     } else if (command_exists("kdialog")) {
-        cmd = "kdialog --getsavefilename \"" + preferred_name + "\"";
+        cmd = "kdialog --getsavefilename " + safe_preferred_name;
     }
 
     if (!cmd.empty()) {


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `SystemDialogs::SaveFileDialog` method was susceptible to command injection because a user-provided string `preferred_name` was concatenated without sanitization into shell commands for `zenity` and `kdialog` via `popen`.
🎯 **Impact**: An attacker who can control the `preferred_name` string could potentially execute arbitrary code on the underlying host operating system.
🔧 **Fix**: Implemented a helper function `escape_shell_arg` that wraps string arguments in single quotes and safely escapes internal single quotes. `SystemDialogs::SaveFileDialog` now uses this function to escape the `preferred_name` before invoking the shell command.
✅ **Verification**: Verified using the `app:assembleDebug` and `app:test` Gradle commands as well as the native CMake build. All test checks passed successfully.

---
*PR created automatically by Jules for task [8645509971954743095](https://jules.google.com/task/8645509971954743095) started by @telecomadm1145*