### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in Linux fallback file dialog

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-25 - Fix command injection in Linux fallback file dialog
+**Vulnerability:** Unescaped user input (`preferred_name`) was directly interpolated into shell commands (`zenity` and `kdialog`) executed via `popen` in `SystemDialogs::SaveFileDialog` when running on Linux desktop without native COM/JNI support.
+**Learning:** Shell execution functions (`popen`, `system`) are inherently risky. When creating a fallback implementation for cross-platform components, verify that any data derived from user input or external configuration is securely escaped.
+**Prevention:** Implement and enforce usage of a shell escaping utility (like `escape_shell_arg` replacing `'` with `'\''` inside single quotes) before passing string variables into system commands.

--- a/CasioEmuMsvc/Ext/SysDialog.cpp
+++ b/CasioEmuMsvc/Ext/SysDialog.cpp
@@ -416,6 +416,19 @@ void terminal_fallback(const std::string& prompt, const std::function<void(std::
     }
 }
 
+std::string escape_shell_arg(const std::string& arg) {
+    std::string result = "'";
+    for (char c : arg) {
+        if (c == '\'') {
+            result += "'\\''";
+        } else {
+            result += c;
+        }
+    }
+    result += "'";
+    return result;
+}
+
 void SystemDialogs::OpenFileDialog(std::function<void(std::filesystem::path)> callback) {
     std::string cmd;
     if (command_exists("zenity")) {
@@ -436,10 +449,11 @@ void SystemDialogs::OpenFileDialog(std::function<void(std::filesystem::path)> ca
 
 void SystemDialogs::SaveFileDialog(std::string preferred_name, std::function<void(std::filesystem::path)> callback) {
     std::string cmd;
+    std::string escaped_name = escape_shell_arg(preferred_name);
     if (command_exists("zenity")) {
-        cmd = "zenity --file-selection --save --confirm-overwrite --filename=\"" + preferred_name + "\"";
+        cmd = "zenity --file-selection --save --confirm-overwrite --filename=" + escaped_name;
     } else if (command_exists("kdialog")) {
-        cmd = "kdialog --getsavefilename \"" + preferred_name + "\"";
+        cmd = "kdialog --getsavefilename " + escaped_name;
     }
 
     if (!cmd.empty()) {


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix command injection in Linux file dialog

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unescaped user input (`preferred_name`) was being directly interpolated into a `popen` command string when using the Linux fallback file dialog implementations (`zenity` and `kdialog`).
🎯 **Impact:** If `preferred_name` contained malicious payload characters (like `"; ls; #`), an attacker could achieve arbitrary command execution on the host machine.
🔧 **Fix:** Introduced an `escape_shell_arg` utility function that wraps the user input in single quotes and safely escapes existing single quotes. Applied this to the user input in `SystemDialogs::SaveFileDialog`.
✅ **Verification:** Verified by building the `CasioEmuMsvc` project on a Linux environment (`mkdir -p build && cd build && cmake .. -DBUILD_EXECUTABLE=ON && make -j4 CasioEmuMsvc`) and successfully running the Android `app:test` task. A `.jules/sentinel.md` journal entry was added to document this learning.

---
*PR created automatically by Jules for task [9813153744406324137](https://jules.google.com/task/9813153744406324137) started by @telecomadm1145*