### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in SysDialog.cpp

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Fix Command Injection in File Dialogs]
+**Vulnerability:** The `SaveFileDialog` command in Linux/Mac environments used `zenity` and `kdialog` strings compiled via string concatenation with unescaped filenames (e.g. `cmd = "zenity ... --filename=\"" + preferred_name + "\""`). This allowed for command injection via maliciously crafted paths.
+**Learning:** `popen()` calls require strictly escaped arguments if using user-controlled input, even if inside other quotes within the string.
+**Prevention:** Use an escaping function (like `escape_shell_arg` wrapping in single quotes and safely transforming inner quotes to `'\''`) before combining any variables into shell strings executed by `popen()`, `system()`, or `exec()`.

--- a/CasioEmuMsvc/Ext/SysDialog.cpp
+++ b/CasioEmuMsvc/Ext/SysDialog.cpp
@@ -434,12 +434,23 @@ void SystemDialogs::OpenFileDialog(std::function<void(std::filesystem::path)> ca
     }
 }
 
+static std::string escape_shell_arg(const std::string& arg) {
+    std::string escaped = "'";
+    for (char c : arg) {
+        if (c == '\'') escaped += "'\\''";
+        else escaped += c;
+    }
+    escaped += "'";
+    return escaped;
+}
+
 void SystemDialogs::SaveFileDialog(std::string preferred_name, std::function<void(std::filesystem::path)> callback) {
+    std::string safe_name = escape_shell_arg(preferred_name);
     std::string cmd;
     if (command_exists("zenity")) {
-        cmd = "zenity --file-selection --save --confirm-overwrite --filename=\"" + preferred_name + "\"";
+        cmd = "zenity --file-selection --save --confirm-overwrite --filename=" + safe_name;
     } else if (command_exists("kdialog")) {
-        cmd = "kdialog --getsavefilename \"" + preferred_name + "\"";
+        cmd = "kdialog --getsavefilename " + safe_name;
     }
 
     if (!cmd.empty()) {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unescaped strings derived from user-controlled paths (`preferred_name`) were concatenated directly into shell commands (`zenity` / `kdialog`) and passed to `popen()`. This allowed arbitrary command execution.
🎯 **Impact:** An attacker could craft a malicious filename that breaks out of the argument quotes to execute arbitrary shell commands with the privileges of the application.
🔧 **Fix:** Introduced an `escape_shell_arg` helper function that wraps inputs in single quotes and safely transforms any inner single quotes (`' -> '\''`). Applied this escaping to the `preferred_name` variable before concatenating it into the shell command strings.
✅ **Verification:** Verified compilation passes using CMake on Linux. Successfully ran unit tests via `./gradlew app:assembleDebug app:test` ensuring no regressions.

---
*PR created automatically by Jules for task [15038815779196786649](https://jules.google.com/task/15038815779196786649) started by @telecomadm1145*