### PR TITLE
⚡ Bolt: Prevent deep copy in MemBreakPoint ImGui loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
-## 2026-05-05 - [C++ Heterogeneous Lookup in unordered_map]
-**Learning:** By default in C++20, `std::hash<std::string_view>` is not transparent. Using an `std::unordered_map` with `std::string` keys and looking up with `std::string_view` or `const char*` requires implicit construction of `std::string` and heap allocation, which can cause significant performance penalties when called frequently (like in UI rendering loops).
-**Action:** Define a custom transparent hash struct (e.g., `struct StringHash { using is_transparent = void; ... }`) and use it in `std::unordered_map` to enable C++20 heterogeneous lookup and avoid `std::string` heap allocations.
+## $(date +%Y-%m-%d) - [ImGui Loop Deep Copy Bottleneck]
+**Learning:** In hot render loops like ImGui's (running at 60fps), iterating over structures containing strings (or other complex objects) by value (e.g., `for (auto item : container)`) causes a massive amount of unnecessary deep copies and heap allocations. This is a common but devastating anti-pattern in C++ UI code.
+**Action:** Always use `const auto&` for read-only iterations over complex objects in hot paths and render loops to avoid deep copying.

--- a/CasioEmuMsvc/Gui/MemBreakPoint.cpp
+++ b/CasioEmuMsvc/Gui/MemBreakPoint.cpp
@@ -84,7 +84,9 @@ void Breakpoints::DrawFindContent() {
 		);
 		ImGui::TableHeadersRow();
 		int i = 0;
-		for (auto kv : break_point_hash[target_addr].records) {
+		// ⚡ Bolt optimization: Use const auto& to prevent deep copying
+		// the Record (which contains a std::string stacktrace) on every ImGui render frame.
+		for (const auto& kv : break_point_hash[target_addr].records) {
 			ImGui::TableNextRow();
 			ImGui::TableSetColumnIndex(0);
 			ImGui::TextColored(~ImVec4(0, 200, 0, 200), "%01x:%04x", kv.first >> 16, kv.first & 0x0ffff);


### PR DESCRIPTION
⚡ Bolt: Prevent deep copy in MemBreakPoint ImGui loop

💡 What: Changed the range-based for loop `for (auto kv : break_point_hash[target_addr].records)` to `for (const auto& kv : break_point_hash[target_addr].records)` in `MemBreakPoint::DrawFindContent`. Added a comment explaining the performance rationale.
🎯 Why: The previous `auto kv` loop caused a deep copy of the `Record` object (which contains a `std::string stacktrace`) during every iteration. Because this code resides within an ImGui drawing routine, it executed up to 60 times a second, leading to massive unnecessary heap allocations and CPU usage. The `const auto&` approach accesses the `Record` by reference safely, resolving the bottleneck.
📊 Impact: Eliminates unnecessary deep string copies in the UI render loop when rendering active breakpoint lists.
🔬 Measurement: Verify by running the emulator (`CasioEmuMsvc`), setting multiple breakpoints, and observing a reduction in CPU usage and memory allocations compared to the unoptimized build. Build tests run with `cmake` and Android via gradle.

---
*PR created automatically by Jules for task [12126566220605403381](https://jules.google.com/task/12126566220605403381) started by @telecomadm1145*