### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in SysDialog

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-13 - [Command Injection in SystemDialogs]
+**Vulnerability:** The `SystemDialogs::SaveFileDialog` method on Linux concatenated a user-controlled string (`preferred_name`) directly into a shell command for `zenity` or `kdialog` (`cmd = "zenity ... --filename=\"" + preferred_name + "\"";`). A malicious `preferred_name` (e.g. `test"; echo vulnerable; "`) could execute arbitrary commands.
+**Learning:** Shell commands constructed via string concatenation with external input are vulnerable to command injection, even if basic quoting is attempted, because attackers can close the quotes and append their own commands. This affects `popen` and `system` calls.
+**Prevention:** Always use robust escaping functions (like `escape_shell_arg` which safely escapes single quotes and wraps the entire string in single quotes) when passing untrusted data to a shell command, or use APIs that accept argument lists instead of raw shell strings.

--- a/CasioEmuMsvc/Ext/SysDialog.cpp
+++ b/CasioEmuMsvc/Ext/SysDialog.cpp
@@ -382,6 +382,19 @@ std::function<void(std::filesystem::path)> SystemDialogs::fileSaveCallback;
 std::function<void(std::filesystem::path)> SystemDialogs::folderOpenCallback;
 std::function<void(std::filesystem::path)> SystemDialogs::folderSaveCallback;
 
+static std::string escape_shell_arg(const std::string& arg) {
+    std::string result = "'";
+    for (char c : arg) {
+        if (c == '\'') {
+            result += "'\\''";
+        } else {
+            result += c;
+        }
+    }
+    result += "'";
+    return result;
+}
+
 bool command_exists(const char* cmd) {
     std::string check_cmd = "command -v ";
     check_cmd += cmd;
@@ -436,10 +449,11 @@ void SystemDialogs::OpenFileDialog(std::function<void(std::filesystem::path)> ca
 
 void SystemDialogs::SaveFileDialog(std::string preferred_name, std::function<void(std::filesystem::path)> callback) {
     std::string cmd;
+    std::string escaped_name = escape_shell_arg(preferred_name);
     if (command_exists("zenity")) {
-        cmd = "zenity --file-selection --save --confirm-overwrite --filename=\"" + preferred_name + "\"";
+        cmd = "zenity --file-selection --save --confirm-overwrite --filename=" + escaped_name;
     } else if (command_exists("kdialog")) {
-        cmd = "kdialog --getsavefilename \"" + preferred_name + "\"";
+        cmd = "kdialog --getsavefilename " + escaped_name;
     }
 
     if (!cmd.empty()) {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A Command Injection vulnerability in `CasioEmuMsvc/Ext/SysDialog.cpp`'s `SaveFileDialog`. On Linux systems (without graphical desktop portal integration), `zenity` or `kdialog` was launched using a string containing the user-provided `preferred_name`. An attacker could supply a specially crafted filename (e.g. `test"; rm -rf /; "`) to execute arbitrary shell commands.
🎯 **Impact:** If an attacker can control the initial filename suggested by the emulator (e.g. via an imported script or malicious state), they could execute arbitrary code on the host machine.
🔧 **Fix:** Created a robust `escape_shell_arg` function that wraps the target string in single quotes and safely escapes internal single quotes (`'\''`). This neutralizes any shell expansion or command injection attempts.
✅ **Verification:** Verified that the codebase compiles cleanly and that standard string manipulation tests for escaping work properly.

---
*PR created automatically by Jules for task [8383161618338945125](https://jules.google.com/task/8383161618338945125) started by @telecomadm1145*