### PR TITLE
⚡ Bolt: Prevent deep copies in render loop to improve performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-05-05 - [C++ Heterogeneous Lookup in unordered_map]
 **Learning:** By default in C++20, `std::hash<std::string_view>` is not transparent. Using an `std::unordered_map` with `std::string` keys and looking up with `std::string_view` or `const char*` requires implicit construction of `std::string` and heap allocation, which can cause significant performance penalties when called frequently (like in UI rendering loops).
 **Action:** Define a custom transparent hash struct (e.g., `struct StringHash { using is_transparent = void; ... }`) and use it in `std::unordered_map` to enable C++20 heterogeneous lookup and avoid `std::string` heap allocations.
+
+## 2026-05-05 - [C++ Avoiding deep copies in ImGui render loops]
+**Learning:** Using `auto` or value types in range-based for loops or variable assignments inside ImGui rendering loops (which run up to 60 times per second) can cause severe performance degradation if the types contain heap-allocated members like `std::string` or are large structs. This results in excessive memory allocation/deallocation overhead.
+**Action:** Always use `const auto&` for iteration and local variable binding of complex or large structures (e.g., `for (const auto& kv : records)` instead of `for (auto kv : records)`) in rendering logic to avoid implicit deep copies.

--- a/CasioEmuMsvc/Gui/CodeViewer.cpp
+++ b/CasioEmuMsvc/Gui/CodeViewer.cpp
@@ -370,7 +370,7 @@ bool CodeViewer::TryTrigBP(uint8_t seg, uint16_t offset, bool bp_mode) {
 	for (auto it = break_points.begin(); it != break_points.end(); it++) {
 		if (it->second == 1) {
 			// TODO: We ignore a second trigger
-			CodeElem e = codes[it->first];
+			const auto& e = codes[it->first];
 			if (e.offset == pc_cache) {
 				break_points[it->first] = 2;
 				cur_col = it->first;
@@ -403,7 +403,7 @@ void CodeViewer::DrawContent() {
 	while (c.Step()) {
 		first_col = c.DisplayStart;
 		for (int line_i = c.DisplayStart; line_i < c.DisplayEnd; line_i++) {
-			CodeElem e = codes[line_i];
+			const auto& e = codes[line_i];
 			auto it = break_points.find(line_i);
 			auto bb = it == break_points.end();
 			if (!e.is_label) {

--- a/CasioEmuMsvc/Gui/MemBreakPoint.cpp
+++ b/CasioEmuMsvc/Gui/MemBreakPoint.cpp
@@ -84,7 +84,7 @@ void Breakpoints::DrawFindContent() {
 		);
 		ImGui::TableHeadersRow();
 		int i = 0;
-		for (auto kv : break_point_hash[target_addr].records) {
+		for (const auto& kv : break_point_hash[target_addr].records) {
 			ImGui::TableNextRow();
 			ImGui::TableSetColumnIndex(0);
 			ImGui::TextColored(~ImVec4(0, 200, 0, 200), "%01x:%04x", kv.first >> 16, kv.first & 0x0ffff);


### PR DESCRIPTION
💡 **What:** Replaced value types (`auto`) with const references (`const auto&`) in high-frequency ImGui render loops within `MemBreakPoint.cpp` and `CodeViewer.cpp`.
🎯 **Why:** To prevent deep copies of complex structures, particularly those containing large heap-allocated `std::string` members (such as stack traces in `MemBPData_t::records`), which were being copied 60 times a second and causing massive unnecessary memory allocation overhead.
📊 **Impact:** Drastically reduces heap allocations during active debugging/code viewing, significantly improving the responsiveness and reducing the CPU footprint of the emulator's rendering loop.
🔬 **Measurement:** Verify by compiling and running `CasioEmuMsvc` and observing the CPU/memory usage while interacting with the `CodeViewer` and `MemBreakPoint` windows, ensuring the UI remains smooth and responsive without regressions.

Also updated `.jules/bolt.md` with this performance insight.

---
*PR created automatically by Jules for task [3325226756374931927](https://jules.google.com/task/3325226756374931927) started by @telecomadm1145*