### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection in SaveFileDialog

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-14 - Unescaped File Dialog Inputs
+**Vulnerability:** Command injection vulnerability in `SaveFileDialog` due to unescaped user input being concatenated into bash commands for `zenity` and `kdialog`.
+**Learning:** `std::string` concatenation for building shell commands is inherently unsafe if any variable originates from outside strictly controlled internal logic.
+**Prevention:** Always escape variables passed to shell commands (e.g., using a wrapper like `escape_shell_arg` to convert inner single quotes to `'` and wrap the entirety in single quotes), or use execve-style functions that avoid the shell entirely.

--- a/CasioEmuMsvc/Ext/SysDialog.cpp
+++ b/CasioEmuMsvc/Ext/SysDialog.cpp
@@ -382,6 +382,19 @@ std::function<void(std::filesystem::path)> SystemDialogs::fileSaveCallback;
 std::function<void(std::filesystem::path)> SystemDialogs::folderOpenCallback;
 std::function<void(std::filesystem::path)> SystemDialogs::folderSaveCallback;
 
+std::string escape_shell_arg(const std::string& arg) {
+    std::string escaped = "'";
+    for (char c : arg) {
+        if (c == '\'') {
+            escaped += "'\\''";
+        } else {
+            escaped += c;
+        }
+    }
+    escaped += "'";
+    return escaped;
+}
+
 bool command_exists(const char* cmd) {
     std::string check_cmd = "command -v ";
     check_cmd += cmd;
@@ -437,9 +450,9 @@ void SystemDialogs::OpenFileDialog(std::function<void(std::filesystem::path)> ca
 void SystemDialogs::SaveFileDialog(std::string preferred_name, std::function<void(std::filesystem::path)> callback) {
     std::string cmd;
     if (command_exists("zenity")) {
-        cmd = "zenity --file-selection --save --confirm-overwrite --filename=\"" + preferred_name + "\"";
+        cmd = "zenity --file-selection --save --confirm-overwrite --filename=" + escape_shell_arg(preferred_name);
     } else if (command_exists("kdialog")) {
-        cmd = "kdialog --getsavefilename \"" + preferred_name + "\"";
+        cmd = "kdialog --getsavefilename " + escape_shell_arg(preferred_name);
     }
 
     if (!cmd.empty()) {


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix command injection in SaveFileDialog

🚨 Severity: HIGH
💡 Vulnerability: Command injection vulnerability in `SaveFileDialog` due to unescaped user input (the preferred file name) being concatenated directly into shell commands for `zenity` and `kdialog`.
🎯 Impact: A maliciously crafted file name input could allow arbitrary command execution on the host machine.
🔧 Fix: Implemented `escape_shell_arg` to wrap strings in single quotes and safely escape inner single quotes, and applied it to the bash command string construction.
✅ Verification: Build succeeds, strings are now properly sanitized before shell execution.

---
*PR created automatically by Jules for task [101228792021162068](https://jules.google.com/task/101228792021162068) started by @telecomadm1145*