### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in Linux SaveFileDialog

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Command Injection in SystemDialogs]
+**Vulnerability:** The `SystemDialogs::SaveFileDialog` in `CasioEmuMsvc/Ext/SysDialog.cpp` directly concatenated user-provided filename strings into shell commands (`zenity` and `kdialog`) and executed them via `popen`, enabling arbitrary command execution on Linux environments if the `preferred_name` parameter contained shell metacharacters like `"` and `;`.
+**Learning:** Raw string concatenation for executing shell commands with user-provided arguments opens the door for command injection. A static helper function to escape arguments is necessary when built-in libraries (like `system` or `popen`) are used directly instead of functions that execute programs with an argument array.
+**Prevention:** Always escape shell arguments using a robust mechanism like `escape_shell_arg` (which wraps in single quotes and handles internal single quotes safely) when constructing command strings for `popen` or `system`.

--- a/CasioEmuMsvc/Ext/SysDialog.cpp
+++ b/CasioEmuMsvc/Ext/SysDialog.cpp
@@ -404,6 +404,19 @@ std::string exec_and_get_output(const char* cmd) {
     return result;
 }
 
+std::string escape_shell_arg(const std::string& arg) {
+    std::string escaped = "'";
+    for (char c : arg) {
+        if (c == '\'') {
+            escaped += "'\\''";
+        } else {
+            escaped += c;
+        }
+    }
+    escaped += "'";
+    return escaped;
+}
+
 void terminal_fallback(const std::string& prompt, const std::function<void(std::filesystem::path)>& callback) {
     std::cout << "\n[INFO] No graphical file dialog tool (zenity/kdialog) found." << std::endl;
     std::cout << prompt;
@@ -437,9 +450,9 @@ void SystemDialogs::OpenFileDialog(std::function<void(std::filesystem::path)> ca
 void SystemDialogs::SaveFileDialog(std::string preferred_name, std::function<void(std::filesystem::path)> callback) {
     std::string cmd;
     if (command_exists("zenity")) {
-        cmd = "zenity --file-selection --save --confirm-overwrite --filename=\"" + preferred_name + "\"";
+        cmd = "zenity --file-selection --save --confirm-overwrite --filename=" + escape_shell_arg(preferred_name);
     } else if (command_exists("kdialog")) {
-        cmd = "kdialog --getsavefilename \"" + preferred_name + "\"";
+        cmd = "kdialog --getsavefilename " + escape_shell_arg(preferred_name);
     }
 
     if (!cmd.empty()) {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Command Injection in `SystemDialogs::SaveFileDialog` for Linux environments. The `preferred_name` string was directly concatenated into shell commands (`zenity` and `kdialog`) without sanitization, leading to arbitrary command execution when passed to `popen`.
🎯 **Impact:** If an attacker can control the `preferred_name` passed to the save file dialog on Linux, they could execute arbitrary shell commands with the privileges of the emulator process by injecting shell metacharacters (e.g., `"; rm -rf /; "`).
🔧 **Fix:** Introduced an `escape_shell_arg` utility function that safely wraps the argument in single quotes and correctly escapes internal single quotes. Updated `SaveFileDialog` to use this function when constructing the `zenity` and `kdialog` commands.
✅ **Verification:** Verified by compiling the C++ executable (`make CasioEmuMsvc`) and ensuring the Android app still builds/tests correctly (`./gradlew app:test`). The `escape_shell_arg` logic effectively neutralizes typical command injection payloads.

---
*PR created automatically by Jules for task [4021229542094498620](https://jules.google.com/task/4021229542094498620) started by @telecomadm1145*