### PR TITLE
⚡ Bolt: Prevent deep string copies in breakpoint rendering loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-05-05 - [C++ Heterogeneous Lookup in unordered_map]
 **Learning:** By default in C++20, `std::hash<std::string_view>` is not transparent. Using an `std::unordered_map` with `std::string` keys and looking up with `std::string_view` or `const char*` requires implicit construction of `std::string` and heap allocation, which can cause significant performance penalties when called frequently (like in UI rendering loops).
 **Action:** Define a custom transparent hash struct (e.g., `struct StringHash { using is_transparent = void; ... }`) and use it in `std::unordered_map` to enable C++20 heterogeneous lookup and avoid `std::string` heap allocations.
+## 2024-05-15 - [Deep copies in ImGui Rendering Loops]
+**Learning:** ImGui rendering loops in `CasioEmuMsvc` (like `Breakpoints::DrawFindContent()`) execute every frame (up to 60fps). Iterating over collections with complex structures (like `std::unordered_map` containing strings) using `auto` instead of `const auto&` creates unnecessary deep copies every frame, causing performance degradation and excessive heap allocations.
+**Action:** Always use `const auto&` when iterating over collections in rendering loops unless a copy is explicitly required.

--- a/CasioEmuMsvc/Gui/MemBreakPoint.cpp
+++ b/CasioEmuMsvc/Gui/MemBreakPoint.cpp
@@ -84,7 +84,8 @@ void Breakpoints::DrawFindContent() {
 		);
 		ImGui::TableHeadersRow();
 		int i = 0;
-		for (auto kv : break_point_hash[target_addr].records) {
+		// ⚡ Bolt: Use const reference to prevent deep copies of string 'stacktrace' in Record
+		for (const auto& kv : break_point_hash[target_addr].records) {
 			ImGui::TableNextRow();
 			ImGui::TableSetColumnIndex(0);
 			ImGui::TextColored(~ImVec4(0, 200, 0, 200), "%01x:%04x", kv.first >> 16, kv.first & 0x0ffff);


### PR DESCRIPTION
💡 What: Changed the loop over breakpoint records to use `const auto&` instead of `auto`.
🎯 Why: The `Record` structure contains a `std::string stacktrace`. Iterating with `auto` caused a deep copy of this string for every record on every frame in the ImGui rendering loop, creating unnecessary memory churn and performance overhead.
📊 Impact: Eliminates N string heap allocations per frame when viewing the breakpoint callstack window, significantly reducing memory churn and improving UI performance.
🔬 Measurement: Verify by running the emulator, opening the Breakpoints window, and monitoring CPU/memory usage while breakpoints are hit and callstacks are displayed.

---
*PR created automatically by Jules for task [17152543954941979331](https://jules.google.com/task/17152543954941979331) started by @telecomadm1145*