### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace unsafe `sprintf` with `snprintf`

### DIFF
--- a/CasioEmuMsvc/Gui/BitmapViewer.cpp
+++ b/CasioEmuMsvc/Gui/BitmapViewer.cpp
@@ -193,7 +193,7 @@ public:
 				}
 				addr = newAddr;
 				bitOffset = newBitOffset;
-				sprintf(bufaddr, "%08X", addr);
+				snprintf(bufaddr, sizeof(bufaddr), "%08X", addr);
 			}
 		}
 		// —— 4. 添加键盘滚动处理（上下箭头，PageUp，PageDown）
@@ -228,7 +228,7 @@ public:
 				}
 				addr = newAddr;
 				bitOffset = newBitOffset;
-				sprintf(bufaddr, "%08X", addr);
+				snprintf(bufaddr, sizeof(bufaddr), "%08X", addr);
 			}
 		}
 	}

--- a/CasioEmuMsvc/Gui/LabelViewer.cpp
+++ b/CasioEmuMsvc/Gui/LabelViewer.cpp
@@ -15,7 +15,7 @@ void LabelViewer::RenderCore() {
 	for (const auto& lb : labels) {
 		ImGui::PushID(i++);
 		if (ImGui::Button("Label.Copy"_lc)) {
-			sprintf(buf, "%X", static_cast<unsigned int>(lb.start));
+			snprintf(buf, sizeof(buf), "%X", static_cast<unsigned int>(lb.start));
 			ImGui::SetClipboardText(buf);
 		}
 		ImGui::PopID();
@@ -34,7 +34,7 @@ void LabelViewer::RenderCore() {
 	for (auto lb : regs) {
 		ImGui::PushID(i++);
 		if (ImGui::Button("Label.Copy"_lc)) {
-			sprintf(buf, "%X", static_cast<unsigned int>(lb->base));
+			snprintf(buf, sizeof(buf), "%X", static_cast<unsigned int>(lb->base));
 			ImGui::SetClipboardText(buf);
 		}
 		ImGui::PopID();

--- a/CasioEmuMsvc/Gui/hex.hpp
+++ b/CasioEmuMsvc/Gui/hex.hpp
@@ -298,8 +298,8 @@ struct MemoryEditor {
 						ImGui::PushID((void*)addr);
 						if (DataEditingTakeFocus) {
 							ImGui::SetKeyboardFocusHere(0);
-							sprintf(AddrInputBuf, format_data, s.AddrDigitsCount, base_display_addr + addr);
-							sprintf(DataInputBuf, format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
+							snprintf(AddrInputBuf, sizeof(AddrInputBuf), format_data, s.AddrDigitsCount, base_display_addr + addr);
+							snprintf(DataInputBuf, sizeof(DataInputBuf), format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
 						}
 						struct UserData {
 							// FIXME: We should have a way to retrieve the text edit cursor position more easily in the API, this is rather tedious. This is such a ugly mess we may be better off not using InputText() at all here.
@@ -323,7 +323,7 @@ struct MemoryEditor {
 						};
 						UserData user_data;
 						user_data.CursorPos = -1;
-						sprintf(user_data.CurrentBufOverwrite, format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
+						snprintf(user_data.CurrentBufOverwrite, sizeof(user_data.CurrentBufOverwrite), format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
 						ImGuiInputTextFlags flags = ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_NoHorizontalScroll | ImGuiInputTextFlags_CallbackAlways;
 						flags |= ImGuiInputTextFlags_AlwaysOverwrite; // was ImGuiInputTextFlags_AlwaysInsertMode
 						ImGui::SetNextItemWidth(s.GlyphWidth * 2);
@@ -648,8 +648,8 @@ struct MemoryEditor {
 						ImGui::PushID((void*)addr);
 						if (DataEditingTakeFocus) {
 							ImGui::SetKeyboardFocusHere(0);
-							sprintf(AddrInputBuf, format_data, s.AddrDigitsCount, base_display_addr + addr);
-							sprintf(DataInputBuf, format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
+							snprintf(AddrInputBuf, sizeof(AddrInputBuf), format_data, s.AddrDigitsCount, base_display_addr + addr);
+							snprintf(DataInputBuf, sizeof(DataInputBuf), format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
 						}
 						struct UserData {
 							// FIXME: We should have a way to retrieve the text edit cursor position more easily in the API, this is rather tedious. This is such a ugly mess we may be better off not using InputText() at all here.
@@ -673,7 +673,7 @@ struct MemoryEditor {
 						};
 						UserData user_data;
 						user_data.CursorPos = -1;
-						sprintf(user_data.CurrentBufOverwrite, format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
+						snprintf(user_data.CurrentBufOverwrite, sizeof(user_data.CurrentBufOverwrite), format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
 						ImGuiInputTextFlags flags = ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_NoHorizontalScroll | ImGuiInputTextFlags_CallbackAlways;
 						flags |= ImGuiInputTextFlags_AlwaysOverwrite; // was ImGuiInputTextFlags_AlwaysInsertMode
 						ImGui::SetNextItemWidth(s.GlyphWidth * 2);


### PR DESCRIPTION
Replaced `sprintf` with bounds-checked `snprintf` calls across ImGui rendering and label copy functions. This fixes potential buffer overflow vulnerabilities.

---
*PR created automatically by Jules for task [10799124098161994473](https://jules.google.com/task/10799124098161994473) started by @telecomadm1145*