### PR TITLE
⚡ Bolt: Optimize MemBreakPoint render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-05-05 - [C++ Heterogeneous Lookup in unordered_map]
 **Learning:** By default in C++20, `std::hash<std::string_view>` is not transparent. Using an `std::unordered_map` with `std::string` keys and looking up with `std::string_view` or `const char*` requires implicit construction of `std::string` and heap allocation, which can cause significant performance penalties when called frequently (like in UI rendering loops).
 **Action:** Define a custom transparent hash struct (e.g., `struct StringHash { using is_transparent = void; ... }`) and use it in `std::unordered_map` to enable C++20 heterogeneous lookup and avoid `std::string` heap allocations.
+
+## 2026-05-05 - [Avoid deep copies in UI loops]
+**Learning:** C++ range-based for loops using `auto` instead of `const auto&` on collections with objects that allocate dynamically (e.g. `std::string`) will trigger heap allocations and copying every iteration. In an ImGui application, this happens 60 times a second, creating measurable GC/allocation bottlenecks.
+**Action:** Always inspect loops in render/UI methods for unintentional pass-by-value of complex types. Always prefer `const auto&` for iteration over maps/vectors of structs.

--- a/CasioEmuMsvc/Gui/MemBreakPoint.cpp
+++ b/CasioEmuMsvc/Gui/MemBreakPoint.cpp
@@ -84,7 +84,8 @@ void Breakpoints::DrawFindContent() {
 		);
 		ImGui::TableHeadersRow();
 		int i = 0;
-		for (auto kv : break_point_hash[target_addr].records) {
+		// Bolt: Avoid deep copy of Record (which contains std::string) in the render loop by passing by const reference
+		for (const auto& kv : break_point_hash[target_addr].records) {
 			ImGui::TableNextRow();
 			ImGui::TableSetColumnIndex(0);
 			ImGui::TextColored(~ImVec4(0, 200, 0, 200), "%01x:%04x", kv.first >> 16, kv.first & 0x0ffff);


### PR DESCRIPTION
💡 What: Changed the loop inside `MemBreakPoint.cpp` that iterates over `break_point_hash[target_addr].records` to use `const auto&` instead of `auto`.
🎯 Why: In C++, iterating over a map of structs that contain `std::string` properties with `auto` causes a deep copy (including heap allocation for the string) on every single iteration. Because this code lives inside an ImGui `DrawContent()` function, it runs every frame (up to 60 FPS).
📊 Impact: Eliminates N heap allocations and string copies per frame (where N is the number of breakpoint records), saving significant CPU cycles and reducing garbage collection pressure inside the hot render loop.
🔬 Measurement: No behavior difference; performance improvement is visible in memory profilers as fewer string allocations per second.

---
*PR created automatically by Jules for task [3678143646960972131](https://jules.google.com/task/3678143646960972131) started by @telecomadm1145*