### PR TITLE
🛡️ Sentinel: [HIGH] Fix buffer overflow risks

### DIFF
--- a/CasioEmuMsvc/Gui/BitmapViewer.cpp
+++ b/CasioEmuMsvc/Gui/BitmapViewer.cpp
@@ -193,7 +193,7 @@ public:
 				}
 				addr = newAddr;
 				bitOffset = newBitOffset;
-				sprintf(bufaddr, "%08X", addr);
+				snprintf(bufaddr, sizeof(bufaddr), "%08X", addr);
 			}
 		}
 		// —— 4. 添加键盘滚动处理（上下箭头，PageUp，PageDown）
@@ -228,7 +228,7 @@ public:
 				}
 				addr = newAddr;
 				bitOffset = newBitOffset;
-				sprintf(bufaddr, "%08X", addr);
+				snprintf(bufaddr, sizeof(bufaddr), "%08X", addr);
 			}
 		}
 	}

--- a/CasioEmuMsvc/Gui/LabelViewer.cpp
+++ b/CasioEmuMsvc/Gui/LabelViewer.cpp
@@ -15,7 +15,7 @@ void LabelViewer::RenderCore() {
 	for (const auto& lb : labels) {
 		ImGui::PushID(i++);
 		if (ImGui::Button("Label.Copy"_lc)) {
-			sprintf(buf, "%X", static_cast<unsigned int>(lb.start));
+			snprintf(buf, sizeof(buf), "%X", static_cast<unsigned int>(lb.start));
 			ImGui::SetClipboardText(buf);
 		}
 		ImGui::PopID();
@@ -34,7 +34,7 @@ void LabelViewer::RenderCore() {
 	for (auto lb : regs) {
 		ImGui::PushID(i++);
 		if (ImGui::Button("Label.Copy"_lc)) {
-			sprintf(buf, "%X", static_cast<unsigned int>(lb->base));
+			snprintf(buf, sizeof(buf), "%X", static_cast<unsigned int>(lb->base));
 			ImGui::SetClipboardText(buf);
 		}
 		ImGui::PopID();

--- a/CasioEmuMsvc/Gui/hex.hpp
+++ b/CasioEmuMsvc/Gui/hex.hpp
@@ -298,8 +298,8 @@ struct MemoryEditor {
 						ImGui::PushID((void*)addr);
 						if (DataEditingTakeFocus) {
 							ImGui::SetKeyboardFocusHere(0);
-							sprintf(AddrInputBuf, format_data, s.AddrDigitsCount, base_display_addr + addr);
-							sprintf(DataInputBuf, format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
+							snprintf(AddrInputBuf, sizeof(AddrInputBuf), format_data, s.AddrDigitsCount, base_display_addr + addr);
+							snprintf(DataInputBuf, sizeof(DataInputBuf), format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
 						}
 						struct UserData {
 							// FIXME: We should have a way to retrieve the text edit cursor position more easily in the API, this is rather tedious. This is such a ugly mess we may be better off not using InputText() at all here.
@@ -323,7 +323,7 @@ struct MemoryEditor {
 						};
 						UserData user_data;
 						user_data.CursorPos = -1;
-						sprintf(user_data.CurrentBufOverwrite, format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
+						snprintf(user_data.CurrentBufOverwrite, sizeof(user_data.CurrentBufOverwrite), format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
 						ImGuiInputTextFlags flags = ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_NoHorizontalScroll | ImGuiInputTextFlags_CallbackAlways;
 						flags |= ImGuiInputTextFlags_AlwaysOverwrite; // was ImGuiInputTextFlags_AlwaysInsertMode
 						ImGui::SetNextItemWidth(s.GlyphWidth * 2);
@@ -648,8 +648,8 @@ struct MemoryEditor {
 						ImGui::PushID((void*)addr);
 						if (DataEditingTakeFocus) {
 							ImGui::SetKeyboardFocusHere(0);
-							sprintf(AddrInputBuf, format_data, s.AddrDigitsCount, base_display_addr + addr);
-							sprintf(DataInputBuf, format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
+							snprintf(AddrInputBuf, sizeof(AddrInputBuf), format_data, s.AddrDigitsCount, base_display_addr + addr);
+							snprintf(DataInputBuf, sizeof(DataInputBuf), format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
 						}
 						struct UserData {
 							// FIXME: We should have a way to retrieve the text edit cursor position more easily in the API, this is rather tedious. This is such a ugly mess we may be better off not using InputText() at all here.
@@ -673,7 +673,7 @@ struct MemoryEditor {
 						};
 						UserData user_data;
 						user_data.CursorPos = -1;
-						sprintf(user_data.CurrentBufOverwrite, format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
+						snprintf(user_data.CurrentBufOverwrite, sizeof(user_data.CurrentBufOverwrite), format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
 						ImGuiInputTextFlags flags = ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_NoHorizontalScroll | ImGuiInputTextFlags_CallbackAlways;
 						flags |= ImGuiInputTextFlags_AlwaysOverwrite; // was ImGuiInputTextFlags_AlwaysInsertMode
 						ImGui::SetNextItemWidth(s.GlyphWidth * 2);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Buffer overflow risk due to unsafe use of `sprintf`.
🎯 Impact: While the current buffer sizes are technically sufficient for the data being handled, using `sprintf` is a poor security practice and violates project directives. If future changes modify the data formatting or inputs without adjusting the buffer sizes, it could lead to memory corruption, crashes, or potential code execution vulnerabilities.
🔧 Fix: Replaced `sprintf` with bounds-checked `snprintf` using `sizeof(buffer)` to guarantee memory safety.
✅ Verification: Ran `make CasioEmuMsvc` and `./gradlew app:assembleDebug app:test` to verify correct compilation and no regressions. Validated that only the intended C++ files were modified, discarding accidental formatting changes to localization files.

---
*PR created automatically by Jules for task [12685918356352138410](https://jules.google.com/task/12685918356352138410) started by @telecomadm1145*