### PR TITLE
⚡ Bolt: Optimize `m_missingKeys` lookup overhead

### DIFF
--- a/CasioEmuMsvc/Gui/Localization.h
+++ b/CasioEmuMsvc/Gui/Localization.h
@@ -149,12 +149,15 @@ private:
 	std::string m_currentLocale = "en_US";
 	std::unordered_map<std::string, std::string, StringHash, std::equal_to<>> m_translations;
 	std::unordered_map<std::string, std::vector<PluralRule>, StringHash, std::equal_to<>> m_pluralRules;
-	mutable std::unordered_set<std::string> m_missingKeys;
+	mutable std::unordered_set<std::string, StringHash, std::equal_to<>> m_missingKeys;
 	mutable std::mutex m_missingMutex;
 	void ReportMissingKey(std::string_view key) const {
 		std::lock_guard<std::mutex> lock(m_missingMutex);
 
-		if (m_missingKeys.insert(std::string(key)).second) {
+		// Bolt: Avoid heap allocation on every frame for missing keys
+		// Using C++20 heterogeneous lookup via StringHash, we can search with std::string_view
+		if (m_missingKeys.find(key) == m_missingKeys.end()) {
+			m_missingKeys.insert(std::string(key));
 			// 只会在第一次插入成功时进入
 			fprintf(stderr, "[Localization] Missing key: %.*s\n",
 				(int)key.size(), key.data());


### PR DESCRIPTION
💡 **What:** Enabled C++20 heterogeneous lookup for the `m_missingKeys` `std::unordered_set` in `CasioEmuMsvc/Gui/Localization.h`.

🎯 **Why:** `ReportMissingKey` is invoked whenever a requested UI translation doesn't exist. Because this runs inside ImGui, it can be called 60+ times per second per missing key. The original code unconditionally did `m_missingKeys.insert(std::string(key))`. Even if the key was already in the set, the `std::string(key)` conversion forced a dynamic heap allocation every single frame.

📊 **Impact:** Reduces frame-by-frame memory allocations to zero for cached missing keys.

🔬 **Measurement:** Build `CasioEmuMsvc` and load it with missing translation strings in ImGui views. Use a memory profiler (like Valgrind/Massif) to confirm allocations related to `ReportMissingKey` drop to 1 per missing key instead of 60 per second.

---
*PR created automatically by Jules for task [4419652704819676107](https://jules.google.com/task/4419652704819676107) started by @telecomadm1145*