### PR TITLE
⚡ Bolt: Optimize Localization.h missing key string allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-05-05 - [C++ Heterogeneous Lookup in unordered_map]
 **Learning:** By default in C++20, `std::hash<std::string_view>` is not transparent. Using an `std::unordered_map` with `std::string` keys and looking up with `std::string_view` or `const char*` requires implicit construction of `std::string` and heap allocation, which can cause significant performance penalties when called frequently (like in UI rendering loops).
 **Action:** Define a custom transparent hash struct (e.g., `struct StringHash { using is_transparent = void; ... }`) and use it in `std::unordered_map` to enable C++20 heterogeneous lookup and avoid `std::string` heap allocations.
+## 2024-06-25 - Avoid Implicit String Construction in UI Rendering Loops
+**Learning:** High-frequency paths like UI rendering loops in ImGui can cause significant performance degradation when lookup failures trigger string allocation (e.g., in missing key lookups within `Localization.h`).
+**Action:** Always use C++20 heterogeneous lookup (with transparent hashing `std::equal_to<>`) for `std::unordered_set` or `std::unordered_map` taking `std::string` keys. Before inserting via implicit constructor, check existence using `.find(key) == .end()` to avoid needless heap allocation during rapid fallback attempts.

--- a/CasioEmuMsvc/Gui/Localization.h
+++ b/CasioEmuMsvc/Gui/Localization.h
@@ -149,12 +149,13 @@ private:
 	std::string m_currentLocale = "en_US";
 	std::unordered_map<std::string, std::string, StringHash, std::equal_to<>> m_translations;
 	std::unordered_map<std::string, std::vector<PluralRule>, StringHash, std::equal_to<>> m_pluralRules;
-	mutable std::unordered_set<std::string> m_missingKeys;
+	mutable std::unordered_set<std::string, StringHash, std::equal_to<>> m_missingKeys;
 	mutable std::mutex m_missingMutex;
 	void ReportMissingKey(std::string_view key) const {
 		std::lock_guard<std::mutex> lock(m_missingMutex);
 
-		if (m_missingKeys.insert(std::string(key)).second) {
+		if (m_missingKeys.find(key) == m_missingKeys.end()) {
+			m_missingKeys.insert(std::string(key));
 			// 只会在第一次插入成功时进入
 			fprintf(stderr, "[Localization] Missing key: %.*s\n",
 				(int)key.size(), key.data());


### PR DESCRIPTION
⚡ Bolt: Optimize Localization.h missing key string allocations

💡 What:
Updated `m_missingKeys` in `Localization.h` to use a transparent hash function (`std::unordered_set<std::string, StringHash, std::equal_to<>>`). This allows the `ReportMissingKey` fallback method to use heterogeneous lookup (`.find(key)`) with `std::string_view` before performing a `.insert(std::string(key))`.

🎯 Why:
The UI rendering in ImGui executes up to 60 times a second. If there are missing localization keys (which sometimes serve as default texts), the fallback logic in `ReportMissingKey` was silently triggering implicit `std::string` constructors on every lookup to try and insert them into the unordered_set. This created significant, unnecessary heap allocation pressure per frame.

📊 Impact:
Completely eliminates implicit heap-allocated `std::string` constructions for known missing keys within the main render loop.

🔬 Measurement:
Run the emulator with an unsupported locale or a screen showing missing string keys, and trace memory allocation (e.g., via Valgrind or heap profilers) to confirm fewer string allocations per frame. Tested natively and verified against the Android gradle test suite.

---
*PR created automatically by Jules for task [12725819228075391993](https://jules.google.com/task/12725819228075391993) started by @telecomadm1145*