### PR TITLE
⚡ Bolt: Prevent deep copy in MemBreakPoint render loop

### DIFF
--- a/CasioEmuMsvc/Gui/MemBreakPoint.cpp
+++ b/CasioEmuMsvc/Gui/MemBreakPoint.cpp
@@ -84,7 +84,8 @@ void Breakpoints::DrawFindContent() {
 		);
 		ImGui::TableHeadersRow();
 		int i = 0;
-		for (auto kv : break_point_hash[target_addr].records) {
+		// ⚡ Bolt: Prevent deep copy of Record struct (which contains std::string) in 60fps render loop
+		for (const auto& kv : break_point_hash[target_addr].records) {
 			ImGui::TableNextRow();
 			ImGui::TableSetColumnIndex(0);
 			ImGui::TextColored(~ImVec4(0, 200, 0, 200), "%01x:%04x", kv.first >> 16, kv.first & 0x0ffff);


### PR DESCRIPTION
💡 **What:** Changed `auto` to `const auto&` in a range-based for loop in `CasioEmuMsvc/Gui/MemBreakPoint.cpp`.
🎯 **Why:** The loop iterates over `MemBPData_t::records`, whose values are `Record` structs containing a `std::string stacktrace`. Using `auto` caused a deep copy of the string on every iteration of the loop, which executes up to 60 times per second during UI rendering.
📊 **Impact:** Reduces CPU overhead and eliminates heap allocations in the ImGui rendering loop when viewing memory breakpoint records.
🔬 **Measurement:** The emulator builds and runs successfully, and the change has been verified to be completely safe as it only affects read-only access to existing data.

---
*PR created automatically by Jules for task [9420095991695817697](https://jules.google.com/task/9420095991695817697) started by @telecomadm1145*