### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix buffer overflow vulnerabilities in UI components

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The `RomPackage::ExtractTo` method extracted ROM package contents directly using paths defined within the package metadata (`ModelInfo.rom_path`, `ModelInfo.flash_path`, `ModelInfo.interface_path`). A maliciously crafted `.rompackage` file could use absolute paths or relative paths with `..` to perform path traversal and write files outside the intended extraction directory.
 **Learning:** During extraction processes, all paths originating from potentially untrusted external metadata must be explicitly checked to ensure they resolve within the intended destination bounds. Using standard `operator/` with `std::filesystem::path` is unsafe if the right-hand operand is absolute.
 **Prevention:** Implement an `isPathSafe` validator that rejects absolute paths and paths containing `..` components before appending them to the base extraction directory.
+## $(date +%Y-%m-%d) - Fix buffer overflows in C++ files
+**Vulnerability:** Found uses of `sprintf` without buffer bounds checking, leading to potential buffer overflow vulnerabilities in files such as `LabelViewer.cpp`, `BitmapViewer.cpp`, and `hex.hpp`.
+**Learning:** Legacy codebase or unmaintained portions may continue to use `sprintf` to format output strings. Even seemingly safe uses within UI components pose risks if assumptions about data lengths change.
+**Prevention:** Enforce the usage of bounds-checked functions such as `snprintf` by default throughout the C/C++ codebase instead of `sprintf`, and leverage `sizeof(buffer)` when using statically sized character arrays.

--- a/CasioEmuMsvc/Gui/BitmapViewer.cpp
+++ b/CasioEmuMsvc/Gui/BitmapViewer.cpp
@@ -193,7 +193,7 @@ public:
 				}
 				addr = newAddr;
 				bitOffset = newBitOffset;
-				sprintf(bufaddr, "%08X", addr);
+				snprintf(bufaddr, sizeof(bufaddr), "%08X", addr);
 			}
 		}
 		// —— 4. 添加键盘滚动处理（上下箭头，PageUp，PageDown）
@@ -228,7 +228,7 @@ public:
 				}
 				addr = newAddr;
 				bitOffset = newBitOffset;
-				sprintf(bufaddr, "%08X", addr);
+				snprintf(bufaddr, sizeof(bufaddr), "%08X", addr);
 			}
 		}
 	}

--- a/CasioEmuMsvc/Gui/LabelViewer.cpp
+++ b/CasioEmuMsvc/Gui/LabelViewer.cpp
@@ -15,7 +15,7 @@ void LabelViewer::RenderCore() {
 	for (const auto& lb : labels) {
 		ImGui::PushID(i++);
 		if (ImGui::Button("Label.Copy"_lc)) {
-			sprintf(buf, "%X", static_cast<unsigned int>(lb.start));
+			snprintf(buf, sizeof(buf), "%X", static_cast<unsigned int>(lb.start));
 			ImGui::SetClipboardText(buf);
 		}
 		ImGui::PopID();
@@ -34,7 +34,7 @@ void LabelViewer::RenderCore() {
 	for (auto lb : regs) {
 		ImGui::PushID(i++);
 		if (ImGui::Button("Label.Copy"_lc)) {
-			sprintf(buf, "%X", static_cast<unsigned int>(lb->base));
+			snprintf(buf, sizeof(buf), "%X", static_cast<unsigned int>(lb->base));
 			ImGui::SetClipboardText(buf);
 		}
 		ImGui::PopID();

--- a/CasioEmuMsvc/Gui/hex.hpp
+++ b/CasioEmuMsvc/Gui/hex.hpp
@@ -298,8 +298,8 @@ struct MemoryEditor {
 						ImGui::PushID((void*)addr);
 						if (DataEditingTakeFocus) {
 							ImGui::SetKeyboardFocusHere(0);
-							sprintf(AddrInputBuf, format_data, s.AddrDigitsCount, base_display_addr + addr);
-							sprintf(DataInputBuf, format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
+							snprintf(AddrInputBuf, sizeof(AddrInputBuf), format_data, s.AddrDigitsCount, base_display_addr + addr);
+							snprintf(DataInputBuf, sizeof(DataInputBuf), format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
 						}
 						struct UserData {
 							// FIXME: We should have a way to retrieve the text edit cursor position more easily in the API, this is rather tedious. This is such a ugly mess we may be better off not using InputText() at all here.
@@ -323,7 +323,7 @@ struct MemoryEditor {
 						};
 						UserData user_data;
 						user_data.CursorPos = -1;
-						sprintf(user_data.CurrentBufOverwrite, format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
+						snprintf(user_data.CurrentBufOverwrite, sizeof(user_data.CurrentBufOverwrite), format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
 						ImGuiInputTextFlags flags = ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_NoHorizontalScroll | ImGuiInputTextFlags_CallbackAlways;
 						flags |= ImGuiInputTextFlags_AlwaysOverwrite; // was ImGuiInputTextFlags_AlwaysInsertMode
 						ImGui::SetNextItemWidth(s.GlyphWidth * 2);
@@ -648,8 +648,8 @@ struct MemoryEditor {
 						ImGui::PushID((void*)addr);
 						if (DataEditingTakeFocus) {
 							ImGui::SetKeyboardFocusHere(0);
-							sprintf(AddrInputBuf, format_data, s.AddrDigitsCount, base_display_addr + addr);
-							sprintf(DataInputBuf, format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
+							snprintf(AddrInputBuf, sizeof(AddrInputBuf), format_data, s.AddrDigitsCount, base_display_addr + addr);
+							snprintf(DataInputBuf, sizeof(DataInputBuf), format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
 						}
 						struct UserData {
 							// FIXME: We should have a way to retrieve the text edit cursor position more easily in the API, this is rather tedious. This is such a ugly mess we may be better off not using InputText() at all here.
@@ -673,7 +673,7 @@ struct MemoryEditor {
 						};
 						UserData user_data;
 						user_data.CursorPos = -1;
-						sprintf(user_data.CurrentBufOverwrite, format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
+						snprintf(user_data.CurrentBufOverwrite, sizeof(user_data.CurrentBufOverwrite), format_byte, ReadFn ? ReadFn(mem_data, addr) : mem_data[addr]);
 						ImGuiInputTextFlags flags = ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_NoHorizontalScroll | ImGuiInputTextFlags_CallbackAlways;
 						flags |= ImGuiInputTextFlags_AlwaysOverwrite; // was ImGuiInputTextFlags_AlwaysInsertMode
 						ImGui::SetNextItemWidth(s.GlyphWidth * 2);


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix buffer overflow vulnerabilities

🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Multiple usages of `sprintf` were identified in UI components. Since `sprintf` does not perform bounds checking on the destination buffer, this could potentially result in buffer overflows, allowing unintended memory writes if the formatted strings unexpectedly exceed predefined limits.
🎯 **Impact**: Prevents potential crashes, memory corruption, and undefined behavior, enhancing the reliability and safety of the application's memory analysis and UI tools.
🔧 **Fix**: Substituted all identified `sprintf` function calls with their bounds-checked equivalent, `snprintf`, across `LabelViewer.cpp`, `BitmapViewer.cpp`, and `hex.hpp`. Correctly implemented `sizeof(buffer)` parameterization to respect exact string capacities dynamically.
✅ **Verification**: Verified using native test suites and Android application build routines (`assembleDebug` and `test`), compiling without errors and regressions. Confirmed replacements specifically target identified static arrays without altering logic or presentation behavior.

---
*PR created automatically by Jules for task [13272567189931281992](https://jules.google.com/task/13272567189931281992) started by @telecomadm1145*