### PR TITLE
Fix CI build errors and format security warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -65,7 +65,7 @@ jobs:
 
     - name: Upload ${{ matrix.platform_arch }} Build Artifact
       if: matrix.platform == 'windows'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         name: Release-${{ matrix.platform_arch }}
         path: build/CasioEmuMsvc/${{ env.BUILD_CONFIGURATION }}
@@ -73,7 +73,7 @@ jobs:
 
     - name: Set up JDK 21
       if: matrix.platform == 'android'
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v4
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -99,21 +99,21 @@ jobs:
 
     - name: Upload Universal APK
       if: matrix.platform == 'android'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         path: app/build/outputs/apk/release/*-universal-*.apk
         archive: false
 
     - name: Upload arm64-v8a APK
       if: matrix.platform == 'android'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         path: app/build/outputs/apk/release/*-arm64-v8a-*.apk
         archive: false
 
     - name: Upload armeabi-v7a APK
       if: matrix.platform == 'android'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         path: app/build/outputs/apk/release/*-armeabi-v7a-*.apk
         archive: false
@@ -128,7 +128,7 @@ jobs:
 
     - name: Upload Linux Build Artifact
       if: matrix.platform == 'linux'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         name: Release-Linux-x64
         path: |
@@ -146,12 +146,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Download All Artifacts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@v4
       with:
         path: ./artifacts
 
@@ -200,7 +200,7 @@ jobs:
         ls -la release_assets/
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v3
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ env.RELEASE_TAG }}
         name: '🚧 Auto Build ${{ env.RELEASE_TAG }} (Pre-release)'

--- a/CasioEmuMsvc/Gui/Ui.cpp
+++ b/CasioEmuMsvc/Gui/Ui.cpp
@@ -362,10 +362,10 @@ namespace UIHelpers {
 			ImGui::BeginTooltip();
 			if (defaultTarget == JumpTarget::Code) {
 				ImGui::Text("ClickableAddress.CodeJumpTooltip"_lc, addr);
-				ImGui::TextDisabled("ClickableAddress.RightClickHint"_lc);
+				ImGui::TextDisabled("%s", "ClickableAddress.RightClickHint"_lc);
 			} else if (defaultTarget == JumpTarget::Memory) {
 				ImGui::Text("ClickableAddress.MemJumpTooltip"_lc, addr);
-				ImGui::TextDisabled("ClickableAddress.RightClickHint"_lc);
+				ImGui::TextDisabled("%s", "ClickableAddress.RightClickHint"_lc);
 			} else {
 				ImGui::Text("ClickableAddress.BothTooltip"_lc, addr);
 			}


### PR DESCRIPTION
This PR fixes the CI pipeline failures by updating invalid GitHub action versions to their current valid major versions. It also resolves a compiler warning (`-Wformat-security`) treated as an error by correctly formatting localized strings in `ImGui::TextDisabled`.

---
*PR created automatically by Jules for task [498792004513324591](https://jules.google.com/task/498792004513324591) started by @telecomadm1145*