### PR TITLE
feat: Detect screen size and persist debugger window state

### DIFF
--- a/CasioEmuMsvc/src/Gui/ThemeManager.h
+++ b/CasioEmuMsvc/src/Gui/ThemeManager.h
@@ -3,6 +3,7 @@
 #include <imgui.h>
 #include <iostream>
 #include <unordered_map>
+#include <SDL.h>
 
 // ============================================================================
 // ThemeSettings — 序列化数据结构（保持不变以兼容 theme.bin）
@@ -19,7 +20,13 @@ struct ThemeSettings {
 	// Auto-tint (MD3 Monet)
 	bool enableAutoTint = false;
 	ImVec4 seedColor = ImVec4(0.5f, 0.5f, 0.5f, 1.0f);
-  bool enableDiscordRPC = true;
+	bool enableDiscordRPC = true;
+
+	int windowX = SDL_WINDOWPOS_CENTERED;
+	int windowY = SDL_WINDOWPOS_CENTERED;
+	int windowW = 1600;
+	int windowH = 1080;
+
 	void Write(std::ostream& stm) const {
 		Binary::Write(stm, isDarkMode);
 		stm.write(language, sizeof(language));
@@ -31,6 +38,10 @@ struct ThemeSettings {
 		Binary::Write(stm, enableAutoTint);
 		Binary::Write(stm, seedColor);
 		Binary::Write(stm, enableDiscordRPC);
+		Binary::Write(stm, windowX);
+		Binary::Write(stm, windowY);
+		Binary::Write(stm, windowW);
+		Binary::Write(stm, windowH);
 	}
 
 	void Read(std::istream& stm) {
@@ -49,6 +60,12 @@ struct ThemeSettings {
 		}
 		if (stm.peek() != EOF) {
 			Binary::Read(stm, enableDiscordRPC);
+		}
+		if (stm.peek() != EOF) {
+			Binary::Read(stm, windowX);
+			Binary::Read(stm, windowY);
+			Binary::Read(stm, windowW);
+			Binary::Read(stm, windowH);
 		}
 	}
 };

--- a/CasioEmuMsvc/src/Gui/Ui.cpp
+++ b/CasioEmuMsvc/src/Gui/Ui.cpp
@@ -247,10 +247,30 @@ CodeViewer* test_gui(bool* guiCreated, SDL_Window* wnd, SDL_Renderer* rnd) {
 		(int)ThemeManager::Instance().windowHeight,
 		SDL_WINDOW_RESIZABLE);
 #else
+	int winX = ThemeManager::Instance().Settings().windowX;
+	int winY = ThemeManager::Instance().Settings().windowY;
+	int winW = ThemeManager::Instance().Settings().windowW;
+	int winH = ThemeManager::Instance().Settings().windowH;
+
+	SDL_Rect bounds;
+	if (SDL_GetDisplayUsableBounds(0, &bounds) == 0) {
+		if (winW > bounds.w) winW = bounds.w;
+		if (winH > bounds.h) winH = bounds.h;
+
+		if (winX != SDL_WINDOWPOS_CENTERED) {
+			if (winX < bounds.x) winX = bounds.x;
+			if (winX + winW > bounds.x + bounds.w) winX = bounds.x + bounds.w - winW;
+		}
+		if (winY != SDL_WINDOWPOS_CENTERED) {
+			if (winY < bounds.y) winY = bounds.y;
+			if (winY + winH > bounds.y + bounds.h) winY = bounds.y + bounds.h - winH;
+		}
+	}
+
 	window = SDL_CreateWindow("CasioEmuMsvc Debugger",
-		SDL_WINDOWPOS_CENTERED,
-		SDL_WINDOWPOS_CENTERED,
-		1600, 1080,
+		winX,
+		winY,
+		winW, winH,
 		SDL_WINDOW_RESIZABLE);
 #endif
 #ifdef _WIN32
@@ -409,6 +429,22 @@ namespace UIHelpers {
 
 
 void gui_cleanup() {
+#ifndef __ANDROID__
+#ifndef SINGLE_WINDOW
+	if (window) {
+		int x, y, w, h;
+		SDL_GetWindowPosition(window, &x, &y);
+		SDL_GetWindowSize(window, &w, &h);
+
+		ThemeManager::Instance().Settings().windowX = x;
+		ThemeManager::Instance().Settings().windowY = y;
+		ThemeManager::Instance().Settings().windowW = w;
+		ThemeManager::Instance().Settings().windowH = h;
+		ThemeManager::Instance().SaveSettings();
+	}
+#endif
+#endif
+
 	ImGui_ImplSDLRenderer2_Shutdown();
 	ImGui_ImplSDL2_Shutdown();
 	ImGui::DestroyContext();


### PR DESCRIPTION
This PR implements a quality-of-life feature to persist the debugger window's position and size. It also ensures that the window does not spawn out of bounds or overlap outside the user's usable display area (e.g., if the user switches to a smaller monitor).

---
*PR created automatically by Jules for task [13212484454336590631](https://jules.google.com/task/13212484454336590631) started by @telecomadm1145*